### PR TITLE
Loading erc20 details on start, from hardcoded list of addresses

### DIFF
--- a/src/api/tokenAddresses.ts
+++ b/src/api/tokenAddresses.ts
@@ -1,22 +1,17 @@
 // TODO: refactor and get these from the same file instead of repeating it everywhere
-export enum Network {
-  Mainnet = 1,
-  Ropsten = 3,
-  Rinkeby = 4,
-  Goerli = 5,
-  Kovan = 42,
-}
+
+import { Network } from "utils/constants";
 
 // TODO: dynamically load from a TCR
 const tokenAddresses: { [networkId: number]: string[] } = {
-  [Network.Mainnet]: [
+  [Network.mainnet]: [
     "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // weth
     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // usdc
     "0x6B175474E89094C44Da98b954EedeAC495271d0F", // dai
     "0x6810e776880C02933D47DB1b9fc05908e5386b96", // gno
     "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4", // owl
   ],
-  [Network.Rinkeby]: [
+  [Network.rinkeby]: [
     "0xc778417E063141139Fce010982780140Aa0cD5Ab", // weth
     "0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b", // usdc
     "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa", // dai

--- a/src/api/tokenAddresses.ts
+++ b/src/api/tokenAddresses.ts
@@ -1,0 +1,33 @@
+// TODO: refactor and get these from the same file instead of repeating it everywhere
+export enum Network {
+  Mainnet = 1,
+  Ropsten = 3,
+  Rinkeby = 4,
+  Goerli = 5,
+  Kovan = 42,
+}
+
+// TODO: dynamically load from a TCR
+const tokenAddresses: { [networkId: number]: string[] } = {
+  [Network.Mainnet]: [
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // weth
+    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // usdc
+    "0x6B175474E89094C44Da98b954EedeAC495271d0F", // dai
+    "0x6810e776880C02933D47DB1b9fc05908e5386b96", // gno
+    "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4", // owl
+  ],
+  [Network.Rinkeby]: [
+    "0xc778417E063141139Fce010982780140Aa0cD5Ab", // weth
+    "0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b", // usdc
+    "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa", // dai
+    "0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c", // gno
+    "0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D", // owl
+  ],
+};
+
+// TODO: no need to be async now, but when we load it from a TCR it'll be
+export async function getTokenAddressesForNetwork(
+  network: Network
+): Promise<string[]> {
+  return tokenAddresses[network] || [];
+}

--- a/src/api/tx/index.js
+++ b/src/api/tx/index.js
@@ -1,16 +1,6 @@
-const NETWORK = process.env.NETWORK || "local";
+import { SAFE_ENDPOINT_URL, NETWORK } from "../../utils/constants";
 
-const RINKEBY = "rinkeby";
-const MAINNET = "mainnet";
-
-const NETWORK_API_URLS = {
-  [RINKEBY]: `https://safe-transaction.rinkeby.gnosis.io/`,
-  [MAINNET]: `https://safe-transaction.gnosis.io/`,
-};
-
-export const API_URL = NETWORK_API_URLS[NETWORK];
-
-if (!API_URL) {
+if (!SAFE_ENDPOINT_URL) {
   throw new Error(
     `Network ${NETWORK} has no API_URL configured. - Please define a different network using the env variable NETWORK or add the API_URL to src/api/tx/index.js`
   );
@@ -18,10 +8,10 @@ if (!API_URL) {
 
 export const getTransactions = async (safeAddress) => {
   const response = await fetch(
-    `${API_URL}/api/v1/safes/${safeAddress}/transactions`
+    `${SAFE_ENDPOINT_URL}/api/v1/safes/${safeAddress}/transactions`
   );
   const txs = await response.json();
-  console.log(txs)
+  console.log(txs);
 
   return txs.results;
 };

--- a/src/routes/Deploy/index.js
+++ b/src/routes/Deploy/index.js
@@ -34,20 +34,6 @@ const useFormField = (defaultValue) => {
 };
 
 const DEFAULT_NUM_SAFES = 10;
-const TOKENS_AVAILABLE = [
-  {
-    name: "WETH9",
-    address: "0xc778417E063141139Fce010982780140Aa0cD5Ab",
-  },
-  {
-    name: "DAI",
-    address: "0xeF77ce798401dAc8120F77dc2DebD5455eDdACf9",
-  },
-  {
-    name: "GNO",
-    address: "0x333EDe87B78D89D8F7B670488Efe96B9797dB635",
-  }
-];
 
 const FormBox = styled(Box)`
   max-width: 600px;
@@ -71,12 +57,12 @@ const Deploy = ({ history }) => {
 
   const tokenSelectValues = useMemo(
     () =>
-      TOKENS_AVAILABLE.map(({ name, address, icon }) => ({
+      web3Context.tokenList.map(({ name, address, icon }) => ({
         id: address,
         label: name,
         iconUrl: icon,
       })),
-    []
+    [web3Context]
   );
 
   const handleDeploy = useCallback(async () => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,20 @@
+export enum Network {
+  mainnet = 1,
+  ropsten = 3,
+  rinkeby = 4,
+  goerli = 5,
+  kovan = 42,
+}
+
+export const NETWORK = process.env.NETWORK.toLowerCase();
+export const API_KEY = process.env.INFURA_API_KEY;
+
+export const NETWORK_URL = `https://${NETWORK}.infura.io/v3/${API_KEY}`;
+
+const SAFE_ENDPOINT_URLS = {
+  [Network.rinkeby]: `https://safe-transaction.rinkeby.gnosis.io/`,
+  [Network.mainnet]: `https://safe-transaction.gnosis.io/`,
+};
+
+export const SAFE_ENDPOINT_URL =
+  SAFE_ENDPOINT_URLS[Network[NETWORK]] || SAFE_ENDPOINT_URLS[Network.rinkeby];

--- a/src/utils/initWeb3.js
+++ b/src/utils/initWeb3.js
@@ -1,28 +1,9 @@
 import Web3 from "web3";
-const NETWORK = process.env.NETWORK || "local";
-const API_KEY = process.env.INFURA_API_KEY;
 
-export const RINKEBY = "rinkeby";
-export const MAINNET = "mainnet";
-
-const NETWORK_INFURA_NODES = {
-  [RINKEBY]: `https://rinkeby.infura.io/v3/${API_KEY}`,
-  [MAINNET]: `https://mainnet.infura.io/v3/${API_KEY}`,
-};
-
-if (!API_KEY)
-  throw new Error(
-    "Missing Infura key - please define the env variable `INFURA_API_KEY`"
-  );
-if (!(NETWORK in NETWORK_INFURA_NODES))
-  throw new Error(
-    `Invalid or missing Network defined, no valid Infura API URL avaialble for ${NETWORK}`
-  );
+import { NETWORK_URL } from "./constants";
 
 const initWeb3 = () => {
-  const networkUrl = NETWORK_INFURA_NODES[NETWORK];
-
-  const web3 = new Web3(networkUrl);
+  const web3 = new Web3(NETWORK_URL);
 
   return web3;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,23 @@ const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const path = require("path");
 const webpack = require("webpack");
 
+// Make sure required envs are set
+if (!process.env.INFURA_API_KEY) {
+  throw new Error(
+    "Missing Infura key - please define the env variable `INFURA_API_KEY`"
+  );
+}
+
+const ALLOWED_NETWORKS = ["mainnet", "rinkeby", "local"];
+
+if (!ALLOWED_NETWORKS.includes(process.env.NETWORK)) {
+  throw new Error(
+    `Invalid or missing Network defined - please set NETWORK env variable with one of: ${ALLOWED_NETWORKS.join(
+      ", "
+    )}`
+  );
+}
+
 module.exports = {
   devtool: "eval-source-map",
   module: {


### PR DESCRIPTION
Exposing 2 new properties on Web3Provider:

- `tokenList`: list containing details (decimals, name, symbol, address) for all loaded tokens, to be used for example on select dropdowns
- `getErc20Details`: async function to fetch details. If not on cache, fetches from contract.

Also, added a temporary hard coded list of token addresses by network, to in the future be loaded from a TCR.

New list can be seen in action on `deploy strategy`: 
![screenshot_2020-08-14_14-22-32](https://user-images.githubusercontent.com/43217/90293729-9b67e180-de39-11ea-9758-381aaf2c5e34.png)
