### PR TITLE
Feature/#7/tooltip component

### DIFF
--- a/src/components/labels/LabelWithTooltip/index.tsx
+++ b/src/components/labels/LabelWithTooltip/index.tsx
@@ -7,6 +7,8 @@ import {
 } from "@gnosis.pm/safe-react-components/dist/theme";
 import { Text, Icon } from "@gnosis.pm/safe-react-components";
 
+import { Tooltip } from "components/misc/Tooltip";
+
 const Wrapper = styled.div`
   display: flex;
   flex-wrap: nowrap;
@@ -33,7 +35,15 @@ export const LabelWithTooltip = (props: Props): JSX.Element => {
       <Text size={size} strong color={color}>
         {text}
       </Text>
-      <Icon size="sm" type="question" tooltip={tooltip} />
+      <Tooltip title={tooltip}>
+        <span>
+          {/* Needs the extra <span> wrap because... it's disabled?
+            https://material-ui.com/components/tooltips/#disabled-elements
+            Not sure, but doesn't work without it
+          */}
+          <Icon size="sm" type="question" />
+        </span>
+      </Tooltip>
     </Wrapper>
   );
 };

--- a/src/components/misc/Tooltip/Tooltip.stories.tsx
+++ b/src/components/misc/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Meta } from "@storybook/react/types-6-0";
+
+import { Tooltip, Props } from ".";
+
+export default {
+  component: Tooltip,
+  title: "Tooltip",
+  // Our exports that end in "Data" are not stories.
+  excludeStories: /.*Data$/,
+} as Meta;
+
+const Template = (args: Props): JSX.Element => (
+  <div>
+    This text has a tooltip{" "}
+    <Tooltip {...args}>
+      <span style={{ borderBottom: "1px dashed black" }}>here</span>
+    </Tooltip>
+  </div>
+);
+
+export const tooltipData = { title: "I am a tooltip!" };
+
+export const Default = Template.bind({});
+Default.args = { ...tooltipData };
+
+export const MultiLineTooltip = Template.bind({});
+MultiLineTooltip.args = {
+  ...tooltipData,
+  title:
+    "Each bracket consists of a single Ethereum address that places a " +
+    "buy-low and a sell-high order. Everytime the price goes through a " +
+    "bracket and activates both orders, the CMM provider earns the spread",
+};
+
+export const Interactive = Template.bind({});
+Interactive.args = {
+  ...tooltipData,
+  interactive: true,
+  title: (
+    <span>
+      Contains a <a href="#">link</a>
+    </span>
+  ),
+};

--- a/src/components/misc/Tooltip/index.tsx
+++ b/src/components/misc/Tooltip/index.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import MaterialUiTooltip, { TooltipProps } from "@material-ui/core/Tooltip";
+import { withStyles } from "@material-ui/core";
+import { theme } from "@gnosis.pm/safe-react-components";
+
+export type Props = Omit<TooltipProps, "arrow">;
+
+const StyledToolTip = withStyles(() => ({
+  tooltip: {
+    backgroundColor: theme.colors.white,
+    color: theme.colors.text,
+    fontSize: theme.text.size.lg.fontSize,
+    lineHeight: theme.text.size.lg.lineHeight,
+    fontFamily: theme.fonts.fontFamily,
+    letterSpacing: 0,
+    textAlign: "center",
+    maxWidth: "200px",
+    padding: "12px",
+    borderRadius: "8px",
+    boxShadow: "1px 2px 10px 0 rgba(40, 54, 61, 0.18)",
+  },
+  arrow: {
+    color: theme.colors.white,
+    width: "2em",
+  },
+  tooltipPlacementLeft: {
+    margin: "0 14px",
+  },
+  tooltipPlacementRight: {
+    margin: "0 14px",
+  },
+  tooltipPlacementTop: {
+    margin: "14px 0",
+  },
+  tooltipPlacementBottom: {
+    margin: "14px 0",
+  },
+}))(MaterialUiTooltip);
+
+/**
+ * Tooltip component applying the styles defined on [CMM design](https://projects.invisionapp.com/d/main/default/#/console/20213446/428757598/inspect)
+ *
+ * Other than the styles, it's still a vanilla [Material UI Tooltip](https://material-ui.com/api/tooltip/)
+ */
+export const Tooltip: React.FC<Props> = (props: Props): JSX.Element => (
+  <StyledToolTip {...props} arrow />
+);


### PR DESCRIPTION
# Description

Added Tooltip component applying the styles defined on [CMM design](https://projects.invisionapp.com/d/main/default/#/console/20213446/428757598/inspect)


![screenshot_2020-08-20_14-22-42](https://user-images.githubusercontent.com/43217/90827331-e88ffb80-e2f0-11ea-998c-25aae53cb26d.png)


# To Test
1. Start storybook: `npm run storybook`
2. Visit http://localhost:6006/?path=/docs/tooltip--default

- [ ] Tooltip styles should match design
- [ ] Tooltip should be displayed when hovering over tagged text

# Background

Other than the styles, it's still a vanilla [Material UI Tooltip](https://material-ui.com/api/tooltip/)