### PR TITLE
Feature/#42/simpler hook mocks

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 const { EnvironmentPlugin } = require("webpack");
+const AliasPlugin = require('enhanced-resolve/lib/AliasPlugin');
 
 const path = require("path");
 
@@ -42,9 +43,13 @@ module.exports = {
     config.module.rules.push(custom.module.rules[0]);
 
     // Aliases for mocking things inside the stories
-    // Requires any hook/* file to have a correnponding mock/file
-    // if it is ever imported in storybook dependency tree
-    config.resolve.alias["hooks"] = path.resolve(__dirname, '../src/mock')
+    // import alias with fallback in case there's no corresponding mock/hook.ts for hooks/hook.ts
+    // from https://github.com/webpack/webpack/issues/6817#issuecomment-542448438
+    config.resolve.plugins = [
+      new AliasPlugin('described-resolve', [
+        { name: 'hooks', alias: [path.resolve(__dirname, '../src/mock'), path.resolve(__dirname, '../src/hooks')] },
+      ], 'resolve')
+    ];
 
     return config;
   },

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -42,18 +42,9 @@ module.exports = {
     config.module.rules.push(custom.module.rules[0]);
 
     // Aliases for mocking things inside the stories
-    config.resolve.alias["hooks/useGetPrice"] = require.resolve(
-      "../src/mock/useGetPrice.ts"
-    );
-    config.resolve.alias["hooks/useTokenList"] = require.resolve(
-      "../src/mock/useTokenList.ts"
-    );
-    config.resolve.alias["hooks/useTokenDetails"] = require.resolve(
-      "../src/mock/useTokenDetails.ts"
-    );
-    config.resolve.alias["hooks/useTokenBalance"] = require.resolve(
-      "../src/mock/useTokenBalance.ts"
-    );
+    // Requires any hook/* file to have a correnponding mock/file
+    // if it is ever imported in storybook dependency tree
+    config.resolve.alias["hooks"] = path.resolve(__dirname, '../src/mock')
 
     return config;
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,8 +7,7 @@ import { theme } from "theme";
 
 import GlobalStyles from "../src/components/GlobalStyle";
 
-import { decorator as useGetPriceDecorator } from "../src/mock/useGetPrice";
-import { decorator as useTokenBalanceDecorator } from "../src/mock/useTokenBalance";
+import { mockHookDecorator } from '../src/mock/mockHookContext';
 
 addDecorator((storyFn) => (
   <ThemeProvider theme={theme}>
@@ -17,8 +16,7 @@ addDecorator((storyFn) => (
   </ThemeProvider>
 ));
 
-addDecorator(useGetPriceDecorator);
-addDecorator(useTokenBalanceDecorator);
+addDecorator(mockHookDecorator);
 
 addParameters({
   options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11824,25 +11824,20 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+      "version": "5.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.10.tgz",
+      "integrity": "sha512-vEyxvHv3f8xl7i7QmTQ6BqKY32acSPQ4dTZo8WRMtcqTDYH9YyXnDxqXsQqBLvdRHUiwl9nVivESiM1RcrxbKQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "^4.2.0",
+        "tapable": "^2.0.0-beta.10"
       },
       "dependencies": {
-        "memory-fs": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-          "dev": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
+        "tapable": {
+          "version": "2.0.0-beta.11",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.0.0-beta.11.tgz",
+          "integrity": "sha512-cAhRzCvMdyJsxmdrSXG8/SUlJG4WJUxD/csuYAybUFjKVt74Y6pTyZ/I1ZK+enmCkWZN0JWxh14G69temaGSiA==",
+          "dev": true
         }
       }
     },
@@ -25652,6 +25647,17 @@
             "supports-color": "^5.3.0"
           }
         },
+        "enhanced-resolve": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+          "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -25663,6 +25669,16 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
         },
         "semver": {
           "version": "6.3.0",
@@ -27217,6 +27233,29 @@
             "y18n": "^4.0.0"
           }
         },
+        "enhanced-resolve": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+          "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+              "dev": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            }
+          }
+        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -27498,6 +27537,17 @@
             }
           }
         },
+        "enhanced-resolve": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+          "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -27527,6 +27577,16 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "p-limit": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-loader": "^8.1.0",
     "copy-webpack-plugin": "^6.0.3",
     "core-js": "^3.6.5",
+    "enhanced-resolve": "^5.0.0-beta.10",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",

--- a/src/mock/mockHookContext.tsx
+++ b/src/mock/mockHookContext.tsx
@@ -4,8 +4,9 @@ import { BaseDecorators, Parameters } from '@storybook/addons'
 const MockHookContext = React.createContext<Parameters>({})
 
 /**
- * create a mock hook with
- * export const useYourOfHook = createMockHook('useYourOfHook', defaultValue?)
+ * to mock useYourHook hook from src/hooks/useYourHook.ts
+ * create a mock hook in src/mock/useYourHook.ts 
+ * export const useYourHook = createMockHook('useYourHook', defaultValue?)
  * 
  * in *.stories.tsx
  * Story.parameter = {

--- a/src/mock/mockHookContext.tsx
+++ b/src/mock/mockHookContext.tsx
@@ -20,7 +20,6 @@ const MockHookContext = React.createContext<Parameters>({})
 export const createMockHook = <T extends (...args: any) => any>(name: string, defaultValue?: ReturnType<T>): T => {
   return ((...args: any[]) => {
     const ctx = useContext(MockHookContext)
-    console.log('ctx', JSON.stringify(ctx, null, 2));
     const mockedHook = ctx[name]
     // if parameters = {useYourHook: Function}, then execute with args
     if (typeof mockedHook === 'function') {
@@ -33,7 +32,6 @@ export const createMockHook = <T extends (...args: any) => any>(name: string, de
 }
 
 export const mockHookDecorator: BaseDecorators<JSX.Element>[0] = (Story, { parameters }) => {
-  console.log('parameters', parameters);
   return (
     <MockHookContext.Provider value={parameters}>
       {Story()}

--- a/src/mock/mockHookContext.tsx
+++ b/src/mock/mockHookContext.tsx
@@ -5,7 +5,7 @@ const MockHookContext = React.createContext<Parameters>({})
 
 /**
  * create a mock hook with
- * export const useYourOfHook = createMockHook('useYourOfHook)
+ * export const useYourOfHook = createMockHook('useYourOfHook', defaultValue?)
  * 
  * in *.stories.tsx
  * Story.parameter = {

--- a/src/mock/mockHookContext.tsx
+++ b/src/mock/mockHookContext.tsx
@@ -1,0 +1,42 @@
+import React, { useContext } from 'react'
+import { BaseDecorators, Parameters } from '@storybook/addons'
+
+const MockHookContext = React.createContext<Parameters>({})
+
+/**
+ * create a mock hook with
+ * export const useYourOfHook = createMockHook('useYourOfHook)
+ * 
+ * in *.stories.tsx
+ * Story.parameter = {
+ *  useYourHook: {whatever hook should return}
+ * }
+ * 
+ * or
+ * Story.parameter = {
+ *  useYourHook: (...whatHookExpectsAsInput) => ({whatever hook should return})
+ * }
+ */
+export const createMockHook = <T extends (...args: any) => any>(name: string, defaultValue?: ReturnType<T>): T => {
+  return ((...args: any[]) => {
+    const ctx = useContext(MockHookContext)
+    console.log('ctx', JSON.stringify(ctx, null, 2));
+    const mockedHook = ctx[name]
+    // if parameters = {useYourHook: Function}, then execute with args
+    if (typeof mockedHook === 'function') {
+      const res = mockedHook(...args)
+      return res
+    }
+    // if not Function, return as is or defaultValue if Nullable
+    return mockedHook ?? defaultValue
+  }) as T
+}
+
+export const mockHookDecorator: BaseDecorators<JSX.Element>[0] = (Story, { parameters }) => {
+  console.log('parameters', parameters);
+  return (
+    <MockHookContext.Provider value={parameters}>
+      {Story()}
+    </MockHookContext.Provider>
+  )
+}

--- a/src/mock/useGetPrice.ts
+++ b/src/mock/useGetPrice.ts
@@ -1,11 +1,5 @@
-import Decimal from "decimal.js";
-
 import { useGetPrice as useGetPriceHook } from "hooks/useGetPrice";
-import { Parameters as StoryParameters, StoryContext } from "@storybook/react";
-
-let price: null | Decimal = null;
-let isLoading = false;
-let error = "";
+import { createMockHook } from "./mockHookContext";
 
 /**
  * Mock version of `useGetPrice` hook.
@@ -18,38 +12,15 @@ let error = "";
  *    isLoading: true,
  *    error: 'Something went wrong'
  *  }
+ * or
+ *  useGetPrice: (...argsPassedToHook) => ({
+ *    price: new Decimal('13'),
+ *    isLoading: true,
+ *    error: 'Something went wrong'
+ *  })
  * }
  */
-export function useGetPrice(
-  ...[params]: Parameters<typeof useGetPriceHook>
-): ReturnType<typeof useGetPriceHook> {
-  return {
-    price: !params.baseToken || !params.quoteToken ? null : price,
-    isLoading,
-    error,
-  };
-}
-
-interface UseGetPriceStoryParameters {
-  price?: Decimal;
-  isLoading?: boolean;
-  error?: string;
-}
-
-interface ExtendedContext extends StoryContext {
-  parameters: StoryParameters & { useGetPrice?: UseGetPriceStoryParameters };
-}
-
-/**
- * Storybook decorator
- */
-export function decorator(
-  story: any,
-  { parameters: { useGetPrice } }: ExtendedContext
-): any {
-  price = useGetPrice?.price || null;
-  isLoading = useGetPrice?.isLoading || false;
-  error = useGetPrice?.error || "";
-
-  return story();
-}
+export const useGetPrice = createMockHook<typeof useGetPriceHook>(
+  "useGetPrice",
+  { price: null, isLoading: false, error: "" }
+);

--- a/src/mock/useTokenBalance.ts
+++ b/src/mock/useTokenBalance.ts
@@ -1,10 +1,5 @@
 import { useTokenBalance as useTokenBalanceHook } from "hooks/useTokenBalance";
-import { Parameters as StoryParameters, StoryContext } from "@storybook/react";
-import BN from "bn.js";
-
-let balance: null | BN = null;
-let isLoading = false;
-let error = "";
+import { createMockHook } from "./mockHookContext";
 
 /**
  * Mock version of `useTokenBalance` hook.
@@ -17,40 +12,15 @@ let error = "";
  *    isLoading: true,
  *    error: 'Something went wrong'
  *  }
+ * or
+ *  useTokenBalance: (...argsPassedToHook) => ({
+ *    price: new BN('13319023810'),
+ *    isLoading: true,
+ *    error: 'Something went wrong'
+ *  })
  * }
  */
-export function useTokenBalance(
-  ...[address]: Parameters<typeof useTokenBalanceHook>
-): ReturnType<typeof useTokenBalanceHook> {
-  return {
-    balance: !address ? null : balance,
-    isLoading,
-    error,
-  };
-}
-
-interface UseTokenBalanceStoryParameters {
-  balance?: BN;
-  isLoading?: boolean;
-  error?: string;
-}
-
-interface ExtendedContext extends StoryContext {
-  parameters: StoryParameters & {
-    useTokenBalance?: UseTokenBalanceStoryParameters;
-  };
-}
-
-/**
- * Storybook decorator
- */
-export function decorator(
-  story: any,
-  { parameters: { useTokenBalance } }: ExtendedContext
-): any {
-  balance = useTokenBalance?.balance || null;
-  isLoading = useTokenBalance?.isLoading || false;
-  error = useTokenBalance?.error || "";
-
-  return story();
-}
+export const useTokenBalance = createMockHook<typeof useTokenBalanceHook>(
+  "useTokenBalance",
+  { balance: null, isLoading: false, error: "" }
+);

--- a/src/mock/useTokenDetails.ts
+++ b/src/mock/useTokenDetails.ts
@@ -1,9 +1,7 @@
 import { useTokenDetails as hook } from "hooks/useTokenDetails";
 import { mockTokenDetails } from "./data";
 
-export function useTokenDetails(
-  ...[token]: Parameters<typeof hook>
-): ReturnType<typeof hook> {
+export const useTokenDetails: typeof hook = (token) => {
   if (!token) {
     return null;
   }
@@ -18,4 +16,4 @@ export function useTokenDetails(
     );
   }
   return token;
-}
+};

--- a/src/mock/useTokenList.ts
+++ b/src/mock/useTokenList.ts
@@ -2,5 +2,5 @@ import { useTokenList as useTokenListHook } from "hooks/useTokenList";
 
 import { mockTokenDetails } from "./data";
 
-export const useTokenList = (): ReturnType<typeof useTokenListHook> =>
+export const useTokenList: typeof useTokenListHook = () =>
   Object.values(mockTokenDetails);


### PR DESCRIPTION
# Description

Simpler and more generic import mocks

- Any hook imported `from hook/<filename>` would be imported `from mock/<filename>` if there is one
- Hook mock returns can be configured without global (not really global but module scoped) vars and without a thousand decorators

