### PR TITLE
Trying out recoil

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
   "env": {
     "node": true,
     "es6": true,
-    "browser": true,
+    "browser": true
   },
   "settings": {
     "react": {
@@ -20,5 +20,14 @@
         "paths": ["src"]
       }
     }
+  },
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "useRecoilCallback"
+      }
+    ]
   }
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,5 @@
 import "../src/wdyr";
 import React from "react";
-import { RecoilRoot } from "recoil";
 import { addDecorator } from "@storybook/react";
 import { addParameters } from "@storybook/react";
 import { ThemeProvider } from "styled-components";
@@ -9,15 +8,17 @@ import { theme } from "theme";
 import GlobalStyles from "../src/components/GlobalStyle";
 
 import { mockHookDecorator } from "../src/mock/mockHookContext";
+import { injectRecoilStateDecorator } from "../src/mock/injectRecoilState";
 
 addDecorator((storyFn) => (
   <ThemeProvider theme={theme}>
     <GlobalStyles />
-    <RecoilRoot>{storyFn()}</RecoilRoot>
+    {storyFn()}
   </ThemeProvider>
 ));
 
 addDecorator(mockHookDecorator);
+addDecorator(injectRecoilStateDecorator);
 
 addParameters({
   options: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,6 @@
 import "../src/wdyr";
 import React from "react";
+import { RecoilRoot } from "recoil";
 import { addDecorator } from "@storybook/react";
 import { addParameters } from "@storybook/react";
 import { ThemeProvider } from "styled-components";
@@ -7,12 +8,12 @@ import { theme } from "theme";
 
 import GlobalStyles from "../src/components/GlobalStyle";
 
-import { mockHookDecorator } from '../src/mock/mockHookContext';
+import { mockHookDecorator } from "../src/mock/mockHookContext";
 
 addDecorator((storyFn) => (
   <ThemeProvider theme={theme}>
     <GlobalStyles />
-    {storyFn()}
+    <RecoilRoot>{storyFn()}</RecoilRoot>
   </ThemeProvider>
 ));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21993,6 +21993,12 @@
         "resolve": "^1.1.6"
       }
     },
+    "recoil": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.0.13.tgz",
+      "integrity": "sha512-2OToaQ8GR//KsdKdaEhMi04QKStLGRpk3qjC58iBpZpUtsByZ4dUy2UJtRcYuhnVlltGZ8HNwcEQRdFOS864SQ==",
+      "dev": true
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "prop-types": "^15.7.2",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-hot-loader": "^4.12.21",
+    "recoil": "0.0.13",
     "ts-loader": "^8.0.2",
     "typescript": "^3.9.7",
     "webpack": "^4.43.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { hot } from "react-hot-loader/root";
+import { RecoilRoot } from "recoil";
 
 import { theme } from "theme";
 
@@ -17,11 +18,13 @@ const App = () => {
     // useStyles and other styling methods from Material-UI will not work!
     <StyledComponentThemeProvider theme={theme}>
       <GlobalStyle />
-      <Web3Provider>
-        <Router>
-          <TabView />
-        </Router>
-      </Web3Provider>
+      <RecoilRoot>
+        <Web3Provider>
+          <Router>
+            <TabView />
+          </Router>
+        </Web3Provider>
+      </RecoilRoot>
     </StyledComponentThemeProvider>
   );
 };

--- a/src/components/basic/display/SubtextAmount/index.tsx
+++ b/src/components/basic/display/SubtextAmount/index.tsx
@@ -46,4 +46,4 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const SubtextAmount = memo(component);
+export const SubtextAmount: typeof component = memo(component);

--- a/src/components/basic/inputs/FundingInput/Label.tsx
+++ b/src/components/basic/inputs/FundingInput/Label.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import styled from "styled-components";
 
 import { Text } from "@gnosis.pm/safe-react-components";
@@ -16,7 +16,7 @@ interface Props {
   error?: boolean;
 }
 
-export const Label = (props: Props): JSX.Element => {
+function component(props: Props): JSX.Element {
   const { onClick, error } = props;
   return (
     <Wrapper {...props}>
@@ -28,4 +28,6 @@ export const Label = (props: Props): JSX.Element => {
       </ButtonLink>
     </Wrapper>
   );
-};
+}
+
+export const Label: typeof component = memo(component);

--- a/src/components/basic/inputs/FundingInput/PerBracketAmount.tsx
+++ b/src/components/basic/inputs/FundingInput/PerBracketAmount.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import BN from "bn.js";
 
 import { formatSmart, parseAmount } from "@gnosis.pm/dex-js";
@@ -14,7 +14,7 @@ export interface Props {
   tokenAddress: string;
 }
 
-export const PerBracketAmount = (props: Props): JSX.Element => {
+function component(props: Props): JSX.Element {
   const { totalAmount, brackets = 0, tokenAddress } = props;
 
   const { tokenDetails } = useTokenDetails(tokenAddress);
@@ -50,4 +50,6 @@ export const PerBracketAmount = (props: Props): JSX.Element => {
       }
     />
   );
-};
+}
+
+export const PerBracketAmount: typeof component = memo(component);

--- a/src/components/pages/deploy/DeployPage.stories.tsx
+++ b/src/components/pages/deploy/DeployPage.stories.tsx
@@ -3,8 +3,6 @@ import BN from "bn.js";
 import Decimal from "decimal.js";
 import { Meta } from "@storybook/react";
 
-import { Text } from "@gnosis.pm/safe-react-components";
-
 import {
   Params as UseDeployStrategyParams,
   Return as UseDeployStrategyReturn,
@@ -12,6 +10,29 @@ import {
 
 import { DeployPageViewer, Props } from "./viewer";
 import { DeployPage } from ".";
+import {
+  baseTokenAddressAtom,
+  baseTokenAmountAtom,
+  errorAtom,
+  highestPriceAtom,
+  isSubmittingAtom,
+  lowestPriceAtom,
+  quoteTokenAddressAtom,
+  quoteTokenAmountAtom,
+  startPriceAtom,
+  totalBracketsAtom,
+} from "./atoms";
+
+const defaultStates = [
+  [baseTokenAddressAtom, "0x6B175474E89094C44Da98b954EedeAC495271d0F"],
+  [quoteTokenAddressAtom, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
+  [lowestPriceAtom, "300"],
+  [startPriceAtom, "323"],
+  [highestPriceAtom, "350"],
+  [baseTokenAmountAtom, "1000"],
+  [quoteTokenAmountAtom, "1000"],
+  [totalBracketsAtom, "10"],
+];
 
 export default {
   component: DeployPageViewer,
@@ -31,76 +52,33 @@ export default {
           ? new BN("0")
           : null,
     }),
+    recoilStates: defaultStates,
   },
 } as Meta;
 
 // Viewer
 
-export const deployPageData: Props = {};
-
-export const filledDeployPageData: Props = {
-  ...deployPageData,
-  baseTokenAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-  quoteTokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-};
-
 const Template = (args: Props): JSX.Element => {
-  const [baseTokenAddress, setBaseTokenAddress] = useState(
-    args.baseTokenAddress
-  );
-  const [quoteTokenAddress, setQuoteTokenAddress] = useState(
-    args.quoteTokenAddress
-  );
-  return (
-    <DeployPageViewer
-      {...args}
-      baseTokenAddress={baseTokenAddress}
-      quoteTokenAddress={quoteTokenAddress}
-      onBaseTokenSelect={setBaseTokenAddress}
-      onQuoteTokenSelect={setQuoteTokenAddress}
-    />
-  );
+  const onSubmit = async (
+    event: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => event.preventDefault();
+
+  return <DeployPageViewer {...args} onSubmit={onSubmit} />;
 };
 
 export const Default = Template.bind({});
-Default.args = { ...deployPageData };
 
 export const Submitting = Template.bind({});
-Submitting.args = { ...deployPageData, isSubmitting: true };
+Submitting.parameters = {
+  recoilStates: [...defaultStates, [isSubmittingAtom, "true"]],
+};
 
 export const WithError = Template.bind({});
-WithError.args = {
-  ...Default.args,
-  ...filledDeployPageData,
-  messages: [{ type: "error", label: "Insufficient DAI balance" }],
-};
-
-export const WithWarning = Template.bind({});
-WithWarning.args = {
-  ...Default.args,
-  ...filledDeployPageData,
-  messages: [
-    {
-      type: "warning",
-      label: "Detected: Start price >2% higher than market price",
-      children: (
-        <Text as="span" size="md" color="shadow">
-          The specified{" "}
-          <Text as="span" size="md" strong>
-            Start Price
-          </Text>{" "}
-          is at least 2% higher than the current indicated market price. If
-          intentional continue with your order.
-        </Text>
-      ),
-    },
+WithError.parameters = {
+  recoilStates: [
+    ...defaultStates,
+    [errorAtom, { label: "Insufficient DAI balance" }],
   ],
-};
-
-export const MultipleMessages = Template.bind({});
-MultipleMessages.args = {
-  ...WithWarning.args,
-  messages: [...WithWarning.args.messages, ...WithError.args.messages],
 };
 
 // Container

--- a/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
+++ b/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
@@ -4,7 +4,8 @@ import styled from "styled-components";
 
 import { Button } from "@gnosis.pm/safe-react-components";
 
-import { isSubmittingAtom, isValidAtom } from "./atoms";
+import { isSubmittingAtom } from "./atoms";
+import { isValidSelector } from "./selectors";
 
 const StyledButton = styled(Button)`
   border-radius: 16px;
@@ -12,7 +13,7 @@ const StyledButton = styled(Button)`
 `;
 
 function component(): JSX.Element {
-  const isValid = useRecoilValue(isValidAtom);
+  const isValid = useRecoilValue(isValidSelector);
   const isSubmitting = useRecoilValue(isSubmittingAtom);
 
   return (

--- a/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
+++ b/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
@@ -1,9 +1,10 @@
-import React, { memo, useContext } from "react";
+import React, { memo } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { Button } from "@gnosis.pm/safe-react-components";
 
-import { DeployPageContext } from "./viewer";
+import { isSubmittingAtom, isValidAtom } from "./atoms";
 
 const StyledButton = styled(Button)`
   border-radius: 16px;
@@ -11,7 +12,8 @@ const StyledButton = styled(Button)`
 `;
 
 function component(): JSX.Element {
-  const { isValid, isSubmitting } = useContext(DeployPageContext);
+  const isValid = useRecoilValue(isValidAtom);
+  const isSubmitting = useRecoilValue(isSubmittingAtom);
 
   return (
     <StyledButton

--- a/src/components/pages/deploy/ErrorMessagesFragment.tsx
+++ b/src/components/pages/deploy/ErrorMessagesFragment.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, memo } from "react";
+import React, { memo } from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { Message } from "components/basic/display/Message";
 
-import { messagesSelector } from "recoil/selectors";
+import { messagesSelector } from "components/pages/deploy/selectors";
 
 const Wrapper = styled.div`
   & > :not(:last-child) {

--- a/src/components/pages/deploy/ErrorMessagesFragment.tsx
+++ b/src/components/pages/deploy/ErrorMessagesFragment.tsx
@@ -1,9 +1,10 @@
 import React, { useContext, memo } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { Message } from "components/basic/display/Message";
 
-import { DeployPageContext } from "./viewer";
+import { messagesSelector } from "recoil/selectors";
 
 const Wrapper = styled.div`
   & > :not(:last-child) {
@@ -12,7 +13,7 @@ const Wrapper = styled.div`
 `;
 
 function component(): JSX.Element {
-  const { messages } = useContext(DeployPageContext);
+  const messages = useRecoilValue(messagesSelector);
 
   if (!messages) {
     return null;

--- a/src/components/pages/deploy/MarketPriceFragment.tsx
+++ b/src/components/pages/deploy/MarketPriceFragment.tsx
@@ -1,16 +1,19 @@
-import React, { useContext, memo } from "react";
+import React, { memo } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { MarketPrice } from "components/basic/display/MarketPrice";
 
-import { DeployPageContext } from "./viewer";
+import { baseTokenAddressAtom, quoteTokenAddressAtom } from "./atoms";
 
 const Wrapper = styled.div`
   align-self: center;
 `;
 
 function component(): JSX.Element {
-  const { baseTokenAddress, quoteTokenAddress } = useContext(DeployPageContext);
+  const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
+  const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
+
   return (
     <Wrapper>
       <MarketPrice

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -1,11 +1,25 @@
-import React, { memo, useContext } from "react";
+import React, { memo } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { PriceInput } from "components/basic/inputs/PriceInput";
 import { FundingInput } from "components/basic/inputs/FundingInput";
 import { TotalBrackets } from "components/basic/inputs/TotalBrackets";
 
-import { DeployPageContext } from "./viewer";
+import { Props as ViewerProps } from "./viewer";
+import {
+  baseTokenAddressAtom,
+  baseTokenAmountAtom,
+  baseTokenBracketsAtom,
+  highestPriceAtom,
+  lowestPriceAtom,
+  quoteTokenAddressAtom,
+  quoteTokenAmountAtom,
+  quoteTokenBracketsAtom,
+  startPriceAtom,
+  totalBracketsAtom,
+  totalInvestmentAtom,
+} from "./atoms";
 
 const Wrapper = styled.div`
   display: flex;
@@ -33,19 +47,18 @@ const Wrapper = styled.div`
   }
 `;
 
-function component(): JSX.Element {
+type Props = Pick<
+  ViewerProps,
+  | "onLowestPriceChange"
+  | "onStartPriceChange"
+  | "onHighestPriceChange"
+  | "onBaseTokenAmountChange"
+  | "onQuoteTokenAmountChange"
+  | "onTotalBracketsChange"
+>;
+
+function component(props: Props): JSX.Element {
   const {
-    baseTokenAddress,
-    quoteTokenAddress,
-    baseTokenAmount,
-    quoteTokenAmount,
-    totalBrackets,
-    totalInvestment,
-    baseTokenBrackets,
-    quoteTokenBrackets,
-    startPrice,
-    lowestPrice,
-    highestPrice,
     // callbacks
     onLowestPriceChange,
     onStartPriceChange,
@@ -53,7 +66,19 @@ function component(): JSX.Element {
     onBaseTokenAmountChange,
     onQuoteTokenAmountChange,
     onTotalBracketsChange,
-  } = useContext(DeployPageContext);
+  } = props;
+
+  const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
+  const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
+  const baseTokenBrackets = useRecoilValue(baseTokenBracketsAtom);
+  const quoteTokenBrackets = useRecoilValue(quoteTokenBracketsAtom);
+  const baseTokenAmount = useRecoilValue(baseTokenAmountAtom);
+  const quoteTokenAmount = useRecoilValue(quoteTokenAmountAtom);
+  const totalBrackets = useRecoilValue(totalBracketsAtom);
+  const totalInvestment = useRecoilValue(totalInvestmentAtom);
+  const startPrice = useRecoilValue(startPriceAtom);
+  const lowestPrice = useRecoilValue(lowestPriceAtom);
+  const highestPrice = useRecoilValue(highestPriceAtom);
 
   return (
     <Wrapper>

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -10,16 +10,18 @@ import { Props as ViewerProps } from "./viewer";
 import {
   baseTokenAddressAtom,
   baseTokenAmountAtom,
-  baseTokenBracketsAtom,
   highestPriceAtom,
   lowestPriceAtom,
   quoteTokenAddressAtom,
   quoteTokenAmountAtom,
-  quoteTokenBracketsAtom,
   startPriceAtom,
   totalBracketsAtom,
   totalInvestmentAtom,
 } from "./atoms";
+import {
+  baseTokenBracketsSelector,
+  quoteTokenBracketsSelector,
+} from "./selectors";
 
 const Wrapper = styled.div`
   display: flex;
@@ -70,8 +72,8 @@ function component(props: Props): JSX.Element {
 
   const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
   const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
-  const baseTokenBrackets = useRecoilValue(baseTokenBracketsAtom);
-  const quoteTokenBrackets = useRecoilValue(quoteTokenBracketsAtom);
+  const baseTokenBrackets = useRecoilValue(baseTokenBracketsSelector);
+  const quoteTokenBrackets = useRecoilValue(quoteTokenBracketsSelector);
   const baseTokenAmount = useRecoilValue(baseTokenAmountAtom);
   const quoteTokenAmount = useRecoilValue(quoteTokenAmountAtom);
   const totalBrackets = useRecoilValue(totalBracketsAtom);

--- a/src/components/pages/deploy/SideBar.tsx
+++ b/src/components/pages/deploy/SideBar.tsx
@@ -134,8 +134,8 @@ function component(): JSX.Element {
         </StyledAccordionSummary>
         <StyledAccordionDetails>
           <ol>
-            {howItWorks.map((item: string) => (
-              <li>{item}</li>
+            {howItWorks.map((item: string, id: number) => (
+              <li key={id}>{item}</li>
             ))}
           </ol>
         </StyledAccordionDetails>

--- a/src/components/pages/deploy/TokenSelectorsFragment.tsx
+++ b/src/components/pages/deploy/TokenSelectorsFragment.tsx
@@ -1,11 +1,14 @@
 import React, { memo, useContext } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import { TokenSelector } from "components/basic/inputs/TokenSelector";
 import { Button, Icon } from "@gnosis.pm/safe-react-components";
 
-import { DeployPageContext } from "./viewer";
+import { TokenSelector } from "components/basic/inputs/TokenSelector";
 import { Link } from "components/basic/inputs/Link";
+
+import { Props as ViewerProps } from "./viewer";
+import { baseTokenAddressAtom, quoteTokenAddressAtom } from "./atoms";
 
 const Wrapper = styled.div`
   display: flex;
@@ -17,14 +20,15 @@ const Wrapper = styled.div`
   }
 `;
 
-function component(): JSX.Element {
-  const {
-    swapTokens,
-    onBaseTokenSelect,
-    onQuoteTokenSelect,
-    baseTokenAddress,
-    quoteTokenAddress,
-  } = useContext(DeployPageContext);
+type Props = Pick<
+  ViewerProps,
+  "swapTokens" | "onBaseTokenSelect" | "onQuoteTokenSelect"
+>;
+
+function component(props: Props): JSX.Element {
+  const { swapTokens, onBaseTokenSelect, onQuoteTokenSelect } = props;
+  const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
+  const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
 
   return (
     <Wrapper>

--- a/src/components/pages/deploy/atoms.ts
+++ b/src/components/pages/deploy/atoms.ts
@@ -34,7 +34,6 @@ export const totalInvestmentAtom = atom({
 });
 
 export const isSubmittingAtom = atom({ key: "isSubmitting", default: false });
-export const isValidAtom = atom({ key: "isValid", default: false });
 export const errorAtom = atom<null | { label: string; body: string }>({
   key: "error",
   default: null,

--- a/src/components/pages/deploy/atoms.ts
+++ b/src/components/pages/deploy/atoms.ts
@@ -20,14 +20,6 @@ export const quoteTokenAmountAtom = atom({
   default: "",
 });
 export const totalBracketsAtom = atom({ key: "totalBrackets", default: "" });
-export const baseTokenBracketsAtom = atom({
-  key: "baseTokenBrackets",
-  default: 0,
-});
-export const quoteTokenBracketsAtom = atom({
-  key: "quoteTokenBrackets",
-  default: 0,
-});
 export const totalInvestmentAtom = atom({
   key: "totalInvestment",
   default: "",

--- a/src/components/pages/deploy/atoms.ts
+++ b/src/components/pages/deploy/atoms.ts
@@ -1,0 +1,41 @@
+import { atom } from "recoil";
+
+export const baseTokenAddressAtom = atom({
+  key: "baseTokenAddress",
+  default: "",
+});
+export const quoteTokenAddressAtom = atom({
+  key: "quoteTokenAddress",
+  default: "",
+});
+export const lowestPriceAtom = atom({ key: "lowestPrice", default: "" });
+export const startPriceAtom = atom({ key: "startPrice", default: "" });
+export const highestPriceAtom = atom({ key: "highestPrice", default: "" });
+export const baseTokenAmountAtom = atom({
+  key: "baseTokenAmount",
+  default: "",
+});
+export const quoteTokenAmountAtom = atom({
+  key: "quoteTokenAmount",
+  default: "",
+});
+export const totalBracketsAtom = atom({ key: "totalBrackets", default: "" });
+export const baseTokenBracketsAtom = atom({
+  key: "baseTokenBrackets",
+  default: 0,
+});
+export const quoteTokenBracketsAtom = atom({
+  key: "quoteTokenBrackets",
+  default: 0,
+});
+export const totalInvestmentAtom = atom({
+  key: "totalInvestment",
+  default: "",
+});
+
+export const isSubmittingAtom = atom({ key: "isSubmitting", default: false });
+export const isValidAtom = atom({ key: "isValid", default: false });
+export const errorAtom = atom<null | { label: string; body: string }>({
+  key: "error",
+  default: null,
+});

--- a/src/components/pages/deploy/index.tsx
+++ b/src/components/pages/deploy/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import {
   RecoilState,
   useRecoilCallback,
@@ -17,8 +17,6 @@ import {
   baseTokenAmountAtom,
   quoteTokenAmountAtom,
   totalBracketsAtom,
-  baseTokenBracketsAtom,
-  quoteTokenBracketsAtom,
   errorAtom,
   isSubmittingAtom,
 } from "./atoms";
@@ -41,6 +39,7 @@ export function DeployPage(): JSX.Element {
   const setHighestPrice = useSetRecoilState(highestPriceAtom);
   const setBaseTokenAmount = useSetRecoilState(baseTokenAmountAtom);
   const setQuoteTokenAmount = useSetRecoilState(quoteTokenAmountAtom);
+  const setTotalBrackets = useSetRecoilState(totalBracketsAtom);
 
   const deployStrategy = useDeployStrategy({
     baseTokenAddress,
@@ -99,29 +98,6 @@ export function DeployPage(): JSX.Element {
     [deployStrategy]
   );
 
-  const onTotalBracketsChange = useRecoilCallback(
-    ({ set }) => (event: React.ChangeEvent<HTMLInputElement>): void => {
-      set(totalBracketsAtom, event.target.value);
-
-      const brackets = +event.target.value;
-
-      // TODO: find out how to properly split brackets when uneven
-      if (brackets >= 1) {
-        if (brackets % 2 === 0) {
-          set(baseTokenBracketsAtom, brackets / 2);
-          set(quoteTokenBracketsAtom, brackets / 2);
-        } else {
-          set(baseTokenBracketsAtom, Math.ceil(brackets / 2));
-          set(quoteTokenBracketsAtom, Math.floor(brackets / 2));
-        }
-      } else {
-        set(baseTokenBracketsAtom, 0);
-        set(quoteTokenBracketsAtom, 0);
-      }
-    },
-    []
-  );
-
   const swapTokens = useRecoilCallback(({ snapshot, set }) => async (): Promise<
     void
   > => {
@@ -164,7 +140,7 @@ export function DeployPage(): JSX.Element {
       onHighestPriceChange: onChangeHandlerFactory(setHighestPrice),
       onBaseTokenAmountChange: onChangeHandlerFactory(setBaseTokenAmount),
       onQuoteTokenAmountChange: onChangeHandlerFactory(setQuoteTokenAmount),
-      onTotalBracketsChange,
+      onTotalBracketsChange: onChangeHandlerFactory(setTotalBrackets),
       onSubmit,
     }),
     [onSubmit]

--- a/src/components/pages/deploy/index.tsx
+++ b/src/components/pages/deploy/index.tsx
@@ -22,7 +22,6 @@ import {
   quoteTokenBracketsAtom,
   errorAtom,
   isSubmittingAtom,
-  isValidAtom,
 } from "./atoms";
 
 import { DeployPageViewer, Props } from "./viewer";
@@ -47,7 +46,6 @@ export function DeployPage(): JSX.Element {
     quoteTokenAmountAtom
   );
   const totalBrackets = useRecoilValue(totalBracketsAtom);
-  const setIsValid = useSetRecoilState(isValidAtom);
 
   const deployStrategy = useDeployStrategy({
     lowestPrice,
@@ -133,10 +131,6 @@ export function DeployPage(): JSX.Element {
       }
     }
   );
-
-  useEffect(() => {
-    setIsValid(!!deployStrategy);
-  }, [deployStrategy]);
 
   const viewerProps: Props = useMemo(
     () => ({

--- a/src/components/pages/deploy/index.tsx
+++ b/src/components/pages/deploy/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "./atoms";
 
 import { DeployPageViewer, Props } from "./viewer";
+import { isValidSelector } from "./selectors";
 
 const onChangeHandlerFactory = (
   setter: React.Dispatch<React.SetStateAction<string>>
@@ -34,6 +35,7 @@ const onChangeHandlerFactory = (
 export function DeployPage(): JSX.Element {
   // input states
   const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
+  const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
   const setLowestPrice = useSetRecoilState(lowestPriceAtom);
   const setStartPrice = useSetRecoilState(startPriceAtom);
   const setHighestPrice = useSetRecoilState(highestPriceAtom);
@@ -42,6 +44,7 @@ export function DeployPage(): JSX.Element {
 
   const deployStrategy = useDeployStrategy({
     baseTokenAddress,
+    quoteTokenAddress,
   });
 
   const onSubmit = useRecoilCallback(
@@ -51,7 +54,9 @@ export function DeployPage(): JSX.Element {
       // TODO: move on to another page/show success message
       event.preventDefault();
 
-      if (deployStrategy) {
+      const isValid = await snapshot.getPromise(isValidSelector);
+
+      if (isValid) {
         set(isSubmittingAtom, true);
         set(errorAtom, null);
 
@@ -63,7 +68,6 @@ export function DeployPage(): JSX.Element {
             baseTokenAmount,
             quoteTokenAmount,
             totalBrackets,
-            quoteTokenAddress,
             startPrice,
           ] = await Promise.all([
             snapshot.getPromise(lowestPriceAtom),
@@ -71,7 +75,6 @@ export function DeployPage(): JSX.Element {
             snapshot.getPromise(baseTokenAmountAtom),
             snapshot.getPromise(quoteTokenAmountAtom),
             snapshot.getPromise(totalBracketsAtom),
-            snapshot.getPromise(quoteTokenAddressAtom),
             snapshot.getPromise(startPriceAtom),
           ]);
 
@@ -81,7 +84,6 @@ export function DeployPage(): JSX.Element {
             baseTokenAmount,
             quoteTokenAmount,
             totalBrackets,
-            quoteTokenAddress,
             startPrice,
           });
         } catch (e) {

--- a/src/components/pages/deploy/selectors.ts
+++ b/src/components/pages/deploy/selectors.ts
@@ -1,5 +1,15 @@
 import { selector } from "recoil";
-import { errorAtom } from "./atoms";
+import {
+  baseTokenAddressAtom,
+  baseTokenAmountAtom,
+  errorAtom,
+  highestPriceAtom,
+  lowestPriceAtom,
+  quoteTokenAddressAtom,
+  quoteTokenAmountAtom,
+  startPriceAtom,
+  totalBracketsAtom,
+} from "./atoms";
 
 // TODO: refactor this type, it's dumb
 import { Props as MessageProps } from "components/basic/display/Message";
@@ -18,5 +28,22 @@ export const messagesSelector = selector({
         },
       ]
     );
+  },
+});
+
+// TODO: dumb validation. Replace when doing real validation
+export const isValidSelector = selector({
+  key: "isValid",
+  get: ({ get }): boolean => {
+    return [
+      get(baseTokenAddressAtom),
+      get(quoteTokenAddressAtom),
+      get(startPriceAtom),
+      get(lowestPriceAtom),
+      get(highestPriceAtom),
+      get(baseTokenAmountAtom),
+      get(quoteTokenAmountAtom),
+      get(totalBracketsAtom),
+    ].every(Boolean);
   },
 });

--- a/src/components/pages/deploy/selectors.ts
+++ b/src/components/pages/deploy/selectors.ts
@@ -47,3 +47,29 @@ export const isValidSelector = selector({
     ].every(Boolean);
   },
 });
+
+export const baseTokenBracketsSelector = selector({
+  key: "baseTokenBrackets",
+  get: ({ get }): number => {
+    const brackets = Number(get(totalBracketsAtom));
+
+    if (brackets >= 1) {
+      return Math.ceil(brackets / 2);
+    } else {
+      return 0;
+    }
+  },
+});
+
+export const quoteTokenBracketsSelector = selector({
+  key: "quoteTokenBrackets",
+  get: ({ get }): number => {
+    const brackets = Number(get(totalBracketsAtom));
+
+    if (brackets >= 1) {
+      return Math.floor(brackets / 2);
+    } else {
+      return 0;
+    }
+  },
+});

--- a/src/components/pages/deploy/selectors.ts
+++ b/src/components/pages/deploy/selectors.ts
@@ -1,0 +1,22 @@
+import { selector } from "recoil";
+import { errorAtom } from "./atoms";
+
+// TODO: refactor this type, it's dumb
+import { Props as MessageProps } from "components/basic/display/Message";
+
+export const messagesSelector = selector({
+  key: "messages",
+  get: ({ get }): null | MessageProps[] => {
+    const error = get(errorAtom);
+
+    return (
+      error && [
+        {
+          type: "error",
+          label: error.label,
+          children: error.body,
+        },
+      ]
+    );
+  },
+});

--- a/src/components/pages/deploy/viewer.tsx
+++ b/src/components/pages/deploy/viewer.tsx
@@ -1,10 +1,9 @@
-import React, { memo, createContext } from "react";
+import React, { memo } from "react";
+import { useRecoilValue } from "recoil";
 import { Backdrop, withStyles } from "@material-ui/core";
 import styled from "styled-components";
 
 import { Loader } from "@gnosis.pm/safe-react-components";
-
-import { Props as MessageProps } from "components/basic/display/Message";
 
 import { SideBar } from "./SideBar";
 import { TokenSelectorsFragment } from "./TokenSelectorsFragment";
@@ -12,6 +11,7 @@ import { PricesFragment } from "./PricesFragment";
 import { MarketPriceFragment } from "./MarketPriceFragment";
 import { ErrorMessagesFragment } from "./ErrorMessagesFragment";
 import { DeployStrategyButtonFragment } from "./DeployStrategyButtonFragment";
+import { isSubmittingAtom } from "./atoms";
 
 const PageLayout = styled.div`
   display: flex;
@@ -48,21 +48,6 @@ const StyledBackdrop = withStyles(() => ({ root: { zIndex: 999 } }))(Backdrop);
 type OnChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => void;
 
 export interface Props {
-  isSubmitting: boolean;
-  isValid: boolean;
-
-  baseTokenAddress?: string;
-  quoteTokenAddress?: string;
-  lowestPrice?: string;
-  highestPrice?: string;
-  startPrice?: string;
-  baseTokenAmount?: string;
-  quoteTokenAmount?: string;
-  totalBrackets?: string;
-  totalInvestment?: string;
-  baseTokenBrackets?: number;
-  quoteTokenBrackets?: number;
-  messages?: MessageProps[];
   // callbacks
   swapTokens?: () => void;
   onBaseTokenSelect?: (address: string) => void;
@@ -76,35 +61,30 @@ export interface Props {
   onSubmit?: (event: React.FormEvent<HTMLFormElement>) => Promise<void>;
 }
 
-export const DeployPageContext = createContext<Props>({
-  isSubmitting: false,
-  isValid: false,
-});
-
 /**
  * All component props are passed down into a local context
  * Every fragment takes what is needs from it
  */
 function component(props: Props): JSX.Element {
+  const isSubmitting = useRecoilValue(isSubmittingAtom);
+
   return (
-    <DeployPageContext.Provider value={props}>
-      <PageLayout>
-        <form onSubmit={props.onSubmit}>
-          <DeployWidget>
-            <TokenSelectorsFragment />
-            <MarketPriceFragment />
-            <PricesFragment />
-            <ErrorMessagesFragment />
-            <DeployStrategyButtonFragment />
-          </DeployWidget>
-        </form>
-        <SideBar />
-        <StyledBackdrop open={props.isSubmitting}>
-          <Loader size="lg" color="primaryLight" />
-        </StyledBackdrop>
-      </PageLayout>
-    </DeployPageContext.Provider>
+    <PageLayout>
+      <form onSubmit={props.onSubmit}>
+        <DeployWidget>
+          <TokenSelectorsFragment {...props} />
+          <MarketPriceFragment />
+          <PricesFragment {...props} />
+          <ErrorMessagesFragment />
+          <DeployStrategyButtonFragment />
+        </DeployWidget>
+      </form>
+      <SideBar />
+      <StyledBackdrop open={isSubmitting}>
+        <Loader size="lg" color="primaryLight" />
+      </StyledBackdrop>
+    </PageLayout>
   );
 }
 
-export const DeployPageViewer = memo(component);
+export const DeployPageViewer: typeof component = memo(component);

--- a/src/hooks/useDeployStrategy.ts
+++ b/src/hooks/useDeployStrategy.ts
@@ -19,43 +19,45 @@ export interface Params {
   startPrice: string;
 }
 
-export type Return = null | (() => Promise<void>);
+export type Return = (
+  params: Omit<Params, "baseTokenAddress">
+) => Promise<void>;
 
-export function useDeployStrategy(params: Params): Return {
-  const {
-    lowestPrice,
-    highestPrice,
-    baseTokenAmount,
-    quoteTokenAmount,
-    totalBrackets,
-    baseTokenAddress,
-    quoteTokenAddress,
-    startPrice,
-  } = params;
+export function useDeployStrategy(
+  params: Pick<Params, "baseTokenAddress">
+): Return {
+  const { baseTokenAddress } = params;
 
   const web3Context = useContext(Web3Context);
   const { tokenDetails: baseTokenDetails } = useTokenDetails(baseTokenAddress);
-  const { tokenDetails: quoteTokenDetails } = useTokenDetails(
-    quoteTokenAddress
-  );
 
   // simple validation
-  if (
-    !lowestPrice ||
-    !highestPrice ||
-    !startPrice ||
-    !baseTokenAmount ||
-    !quoteTokenAmount ||
-    !totalBrackets ||
-    !baseTokenAddress ||
-    !quoteTokenAddress ||
-    !baseTokenDetails ||
-    !quoteTokenDetails
-  ) {
-    return null;
-  }
+  // if (
+  //   !lowestPrice ||
+  //   !highestPrice ||
+  //   !startPrice ||
+  //   !baseTokenAmount ||
+  //   !quoteTokenAmount ||
+  //   !totalBrackets ||
+  //   !baseTokenAddress ||
+  //   !quoteTokenAddress ||
+  //   !baseTokenDetails ||
+  //   !quoteTokenDetails
+  // ) {
+  //   return null;
+  // }
 
-  return async (): Promise<void> => {
+  return async (params): Promise<void> => {
+    const {
+      lowestPrice,
+      highestPrice,
+      baseTokenAmount,
+      quoteTokenAmount,
+      totalBrackets,
+      quoteTokenAddress,
+      startPrice,
+    } = params;
+
     await deployStrategy(
       web3Context,
       +totalBrackets,
@@ -65,7 +67,7 @@ export function useDeployStrategy(params: Params): Return {
       parseAmount(highestPrice, baseTokenDetails.decimals),
       new BN(baseTokenAmount),
       new BN(quoteTokenAmount),
-      new BN(startPrice.toString())
+      new BN(startPrice)
     );
   };
 }

--- a/src/hooks/useDeployStrategy.ts
+++ b/src/hooks/useDeployStrategy.ts
@@ -1,5 +1,6 @@
 import { useContext } from "react";
 import BN from "bn.js";
+import Decimal from "decimal.js";
 
 import { parseAmount } from "@gnosis.pm/dex-js";
 
@@ -7,7 +8,6 @@ import { Web3Context } from "components/Web3Provider";
 import deployStrategy from "api/deployStrategy";
 
 import { useTokenDetails } from "hooks/useTokenDetails";
-import Decimal from "decimal.js";
 
 export interface Params {
   lowestPrice: string;

--- a/src/mock/injectRecoilState.tsx
+++ b/src/mock/injectRecoilState.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { BaseDecorators } from "@storybook/addons";
+import { MutableSnapshot, RecoilRoot } from "recoil";
+
+/**
+ * Allows Recoil states to be initialized with a default value
+ * Takes in a list of tuples of type: [RecoilState<T>, T]
+ *
+ * in *.stories.tsx
+ * Story.parameters ={
+ *  recoilStates: [
+ *    [atom, defaultValue]
+ *  ]
+ * }
+ */
+export const injectRecoilStateDecorator: BaseDecorators<JSX.Element>[0] = (
+  Story,
+  { parameters }
+) => {
+  const { recoilStates } = parameters;
+
+  const initializeState = ({ set }: MutableSnapshot): void => {
+    recoilStates?.map(([atom, state]) => set(atom, state));
+  };
+  return <RecoilRoot initializeState={initializeState}>{Story()}</RecoilRoot>;
+};


### PR DESCRIPTION
# Description

Trying out Recoil

- Removed `Context` from `viewer` component
- Loading all state directly from Recoil
- Passing down callbacks from `container` to `viewer`
- Passing down callbacks from `viewer` to some children, and only the ones each child will need
- Reduced greatly the re-renders, mostly due to splitting what each `viewer` children is consuming
- Loved the `useRecoilCallback` pulling state from `snapshot`, reducing the need to depend on state
- ~:no_entry_sign:  Storybook works for `container`, doesn't work for `viewer`. Still have to figure this one out~ Made a decorator that sets the initial state.

# To Test
- Load storybook, play around with Deploy page

# Background



