### PR TITLE
Feature/#42/fill suggested price

### DIFF
--- a/src/components/basic/display/MarketPrice/index.tsx
+++ b/src/components/basic/display/MarketPrice/index.tsx
@@ -1,20 +1,19 @@
-import React, { useMemo, useEffect, memo } from "react";
+import React, { useEffect, memo, useCallback } from "react";
 
 import { useTokenDetails } from "hooks/useTokenDetails";
 import { useGetPrice } from "hooks/useGetPrice";
-
-import { build1InchPriceUrl } from "utils/priceUrls";
 
 import { MarketPriceViewer } from "./viewer";
 
 export interface Props {
   baseTokenAddress?: string;
   quoteTokenAddress?: string;
+  onPriceClick?: (price: string) => void;
   setError?: (msg?: string) => void;
 }
 
 function component(props: Props): JSX.Element {
-  const { baseTokenAddress, quoteTokenAddress, setError } = props;
+  const { baseTokenAddress, quoteTokenAddress, setError, onPriceClick } = props;
 
   // TODO: handle error
   const { tokenDetails: baseToken } = useTokenDetails(baseTokenAddress);
@@ -27,14 +26,15 @@ function component(props: Props): JSX.Element {
     source: "1inch",
   });
 
+  const onClick = useCallback(() => {
+    if (onPriceClick && price && !isLoading) {
+      onPriceClick(price.toString());
+    }
+  }, [price, isLoading]);
+
   useEffect(() => {
     setError && setError(error);
   }, [error]);
-
-  const priceUrl = useMemo(
-    (): string => build1InchPriceUrl(baseToken, quoteToken),
-    [baseToken, quoteToken]
-  );
 
   return (
     <MarketPriceViewer
@@ -42,7 +42,7 @@ function component(props: Props): JSX.Element {
       quoteTokenAddress={quoteTokenAddress}
       isPriceLoading={isLoading}
       price={price ? price.toString() : ""}
-      priceUrl={priceUrl}
+      onClick={onClick}
     />
   );
 }

--- a/src/components/basic/display/MarketPrice/viewer.tsx
+++ b/src/components/basic/display/MarketPrice/viewer.tsx
@@ -18,18 +18,18 @@ const Amount = styled.span`
 export interface MarketPriceViewerProps {
   price?: string;
   isPriceLoading: boolean;
-  priceUrl: string;
   baseTokenAddress?: string;
   quoteTokenAddress?: string;
+  onClick?: () => void;
 }
 
 function component(props: MarketPriceViewerProps): JSX.Element {
   const {
     price,
     isPriceLoading,
-    priceUrl,
     baseTokenAddress,
     quoteTokenAddress,
+    onClick,
   } = props;
 
   const amount = useMemo((): JSX.Element | string => {
@@ -40,11 +40,7 @@ function component(props: MarketPriceViewerProps): JSX.Element {
     } else {
       return (
         <Amount>
-          <Link
-            color={priceUrl ? "primary" : "disabled"}
-            href={priceUrl}
-            textSize="md"
-          >
+          <Link role="button" color="primary" onClick={onClick} textSize="md">
             {price}
           </Link>
           <TokenDisplay token={quoteTokenAddress} size="md" />
@@ -58,7 +54,7 @@ function component(props: MarketPriceViewerProps): JSX.Element {
         </Amount>
       );
     }
-  }, [price, priceUrl, baseTokenAddress, quoteTokenAddress, isPriceLoading]);
+  }, [isPriceLoading, price, onClick, quoteTokenAddress, baseTokenAddress]);
 
   return <SubtextAmount subtext="Market price:" amount={amount} inline />;
 }

--- a/src/components/pages/deploy/MarketPriceFragment.tsx
+++ b/src/components/pages/deploy/MarketPriceFragment.tsx
@@ -1,10 +1,14 @@
 import React, { memo } from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilCallback, useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { MarketPrice } from "components/basic/display/MarketPrice";
 
-import { baseTokenAddressAtom, quoteTokenAddressAtom } from "./atoms";
+import {
+  baseTokenAddressAtom,
+  quoteTokenAddressAtom,
+  startPriceAtom,
+} from "./atoms";
 
 const Wrapper = styled.div`
   align-self: center;
@@ -14,11 +18,19 @@ function component(): JSX.Element {
   const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
   const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
 
+  const onPriceClick = useRecoilCallback(
+    ({ set }) => async (price: string): Promise<void> => {
+      set(startPriceAtom, price);
+    },
+    []
+  );
+
   return (
     <Wrapper>
       <MarketPrice
         baseTokenAddress={baseTokenAddress}
         quoteTokenAddress={quoteTokenAddress}
+        onPriceClick={onPriceClick}
       />
     </Wrapper>
   );

--- a/src/wdyr.ts
+++ b/src/wdyr.ts
@@ -1,9 +1,10 @@
-import React from "react";
+// import React from "react";
 
-if (process.env.NODE_ENV === "development") {
-  const whyDidYouRender = require("@welldone-software/why-did-you-render");
-  // console.log(`WHY DID YOU RENDER???`, whyDidYouRender);
-  whyDidYouRender(React, {
-    trackAllPureComponents: true,
-  });
-}
+// if (process.env.NODE_ENV === "development") {
+//   const whyDidYouRender = require("@welldone-software/why-did-you-render");
+//   // console.log(`WHY DID YOU RENDER???`, whyDidYouRender);
+//   whyDidYouRender(React, {
+//     trackAllPureComponents: true,
+//   });
+// }
+// TODO: uncomment when testing. Otherwise it's too much noise in the console.


### PR DESCRIPTION
# Description

Part of #42 

Clicking on `market price` suggestion fills in `start price` field:
![screenshot_2020-09-22_08-08-28](https://user-images.githubusercontent.com/43217/93900938-d2d47400-fcaa-11ea-931e-33c952edd22a.png)


# To Test
- [ ] Pick 2 tokens
- [ ] Should display a price estimation
- [ ] Click on the price
- [ ] Should fill `start price` with selected value

# Background

Still using recoil for this. Will refactor when dealing with the form validation.

