### PR TITLE
Bug/#70/bracket calculation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
@@ -52,7 +54,7 @@ module.exports = {
   // forceCoverageMatch: [],
 
   // A path to a module which exports an async function that is triggered once before all test suites
-  // globalSetup: undefined,
+  globalSetup: "<rootDir>/test/globalSetup.ts",
 
   // A path to a module which exports an async function that is triggered once after all test suites
   // globalTeardown: undefined,
@@ -64,7 +66,7 @@ module.exports = {
   // maxWorkers: "50%",
 
   // An array of directory names to be searched recursively up from the requiring module's location
-  moduleDirectories: ["node_modules", "src"],
+  moduleDirectories: ["node_modules", path.resolve(__dirname, "src")],
 
   // An array of file extensions your modules use
   // moduleFileExtensions: [
@@ -131,7 +133,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -6302,6 +6302,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.161",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "dev": true
+    },
     "@types/markdown-to-jsx": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.2.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@truffle/error": "0.0.10",
     "@types/bn.js": "^4.11.6",
     "@types/jest": "^26.0.9",
+    "@types/lodash": "^4.14.161",
     "@types/node": "^14.0.27",
     "@types/react": "^16.9.46",
     "@typescript-eslint/eslint-plugin": "^3.9.0",

--- a/src/components/basic/inputs/FundingInput/FundingInput.stories.tsx
+++ b/src/components/basic/inputs/FundingInput/FundingInput.stories.tsx
@@ -51,3 +51,6 @@ ErrorInput.args = { ...Default.args, error: true };
 
 export const WarningInput = Template.bind({});
 WarningInput.args = { ...Default.args, warn: true };
+
+export const DisabledInput = Template.bind({});
+DisabledInput.args = { ...Default.args, brackets: 0 };

--- a/src/components/basic/inputs/FundingInput/Label.tsx
+++ b/src/components/basic/inputs/FundingInput/Label.tsx
@@ -14,16 +14,28 @@ const Wrapper = styled.span`
 interface Props {
   onClick?: (e: React.SyntheticEvent) => void;
   error?: boolean;
+  disabled?: boolean;
 }
 
 function component(props: Props): JSX.Element {
-  const { onClick, error } = props;
+  const { onClick, error, disabled } = props;
   return (
     <Wrapper {...props}>
-      <Text size="lg" strong color={error ? "error" : null} as="span">
+      <Text
+        size="lg"
+        strong
+        color={error ? "error" : disabled ? "disabled" : null}
+        as="span"
+      >
         Funding
       </Text>
-      <ButtonLink type="button" color="primary" textSize="lg" onClick={onClick}>
+      <ButtonLink
+        type="button"
+        color="primary"
+        textSize="lg"
+        onClick={onClick}
+        disabled={disabled}
+      >
         max
       </ButtonLink>
     </Wrapper>

--- a/src/components/basic/inputs/FundingInput/index.tsx
+++ b/src/components/basic/inputs/FundingInput/index.tsx
@@ -9,10 +9,17 @@ import { NumberInput, Props as NumberInputPros } from "../NumberInput";
 import { PerBracketAmount } from "./PerBracketAmount";
 import { Label } from "./Label";
 
-const Wrapper = styled.div<{ width: string | number }>`
+interface WrapperProps {
+  width: string | number;
+  disabled?: boolean;
+}
+
+const Wrapper = styled.div<WrapperProps>`
   width: ${({ width }) => pxOrCustomCssUnits(width)};
   display: flex;
   flex-direction: column;
+
+  ${({ disabled }) => (disabled ? `opacity: 0.5;` : "")}
 `;
 
 export interface Props extends Omit<NumberInputPros, "customLabel"> {
@@ -32,13 +39,19 @@ export const FundingInput = (props: Props): JSX.Element => {
     ...rest
   } = props;
 
+  const disabled = !brackets;
+
   return (
-    <Wrapper width={width}>
+    <Wrapper width={width} disabled={disabled}>
       <NumberInput
         {...rest}
+        readOnly={disabled}
+        disabled={disabled}
         error={error}
         value={value}
-        customLabel={<Label onClick={onMaxClick} error={error} />}
+        customLabel={
+          <Label onClick={onMaxClick} error={error} disabled={disabled} />
+        }
         width={width}
         tokenAddress={tokenAddress}
       />

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -1,10 +1,12 @@
-import React, { memo, useCallback } from "react";
+import React, { memo, useCallback, useMemo } from "react";
 import { RecoilState, useRecoilCallback, useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { PriceInput } from "components/basic/inputs/PriceInput";
 import { FundingInput } from "components/basic/inputs/FundingInput";
 import { TotalBrackets } from "components/basic/inputs/TotalBrackets";
+
+import { calculateBrackets } from "utils/calculateBrackets";
 
 import {
   baseTokenAddressAtom,
@@ -17,10 +19,6 @@ import {
   totalBracketsAtom,
   totalInvestmentAtom,
 } from "./atoms";
-import {
-  baseTokenBracketsSelector,
-  quoteTokenBracketsSelector,
-} from "./selectors";
 
 const Wrapper = styled.div`
   display: flex;
@@ -51,8 +49,6 @@ const Wrapper = styled.div`
 function component(): JSX.Element {
   const baseTokenAddress = useRecoilValue(baseTokenAddressAtom);
   const quoteTokenAddress = useRecoilValue(quoteTokenAddressAtom);
-  const baseTokenBrackets = useRecoilValue(baseTokenBracketsSelector);
-  const quoteTokenBrackets = useRecoilValue(quoteTokenBracketsSelector);
   const baseTokenAmount = useRecoilValue(baseTokenAmountAtom);
   const quoteTokenAmount = useRecoilValue(quoteTokenAmountAtom);
   const totalBrackets = useRecoilValue(totalBracketsAtom);
@@ -60,6 +56,33 @@ function component(): JSX.Element {
   const startPrice = useRecoilValue(startPriceAtom);
   const lowestPrice = useRecoilValue(lowestPriceAtom);
   const highestPrice = useRecoilValue(highestPriceAtom);
+
+  const { baseTokenBrackets, quoteTokenBrackets } = useMemo(() => {
+    const lp = Number(lowestPrice);
+    const sp = Number(startPrice);
+    const hp = Number(highestPrice);
+    const tb = Number(totalBrackets);
+
+    if (
+      isNaN(lp) ||
+      isNaN(sp) ||
+      isNaN(hp) ||
+      isNaN(tb) ||
+      lp <= 0 ||
+      lp > sp ||
+      sp > hp ||
+      tb <= 0
+    ) {
+      return { baseTokenBrackets: 0, quoteTokenBrackets: 0 };
+    } else {
+      return calculateBrackets({
+        lowestPrice,
+        startPrice,
+        highestPrice,
+        totalBrackets,
+      });
+    }
+  }, [lowestPrice, startPrice, highestPrice, totalBrackets]);
 
   const onChangeHandlerFactory = useRecoilCallback(
     ({ set }) => (atom: RecoilState<string>) => (

--- a/src/components/pages/deploy/selectors.ts
+++ b/src/components/pages/deploy/selectors.ts
@@ -47,29 +47,3 @@ export const isValidSelector = selector({
     ].every(Boolean);
   },
 });
-
-export const baseTokenBracketsSelector = selector({
-  key: "baseTokenBrackets",
-  get: ({ get }): number => {
-    const brackets = Number(get(totalBracketsAtom));
-
-    if (brackets >= 1) {
-      return Math.ceil(brackets / 2);
-    } else {
-      return 0;
-    }
-  },
-});
-
-export const quoteTokenBracketsSelector = selector({
-  key: "quoteTokenBrackets",
-  get: ({ get }): number => {
-    const brackets = Number(get(totalBracketsAtom));
-
-    if (brackets >= 1) {
-      return Math.floor(brackets / 2);
-    } else {
-      return 0;
-    }
-  },
-});

--- a/src/utils/calculateBrackets.ts
+++ b/src/utils/calculateBrackets.ts
@@ -1,0 +1,64 @@
+import Decimal from "decimal.js";
+
+import { ONE_DECIMAL } from "utils/constants";
+
+export interface Params {
+  lowestPrice: string;
+  startPrice: string;
+  highestPrice: string;
+  totalBrackets: string;
+}
+
+interface Result {
+  baseTokenBrackets: number;
+  quoteTokenBrackets: number;
+}
+
+/**
+ * Calculates how many brackets will be used to fund base and quote amounts
+ * All inputs are strings, to be converted internally
+ * Assumes all prices are valid: lowestPrice <= startPrice <= highestPrice
+ *
+ * Based on https://github.com/gnosis/dex-liquidity-provision/blob/525138d8eab5e85536b98a621e6f9abf537fcca/scripts/utils/trading_strategy_helpers.js#L722-L751
+ */
+export function calculateBrackets(params: Params): Result {
+  const {
+    lowestPrice: lowestPriceStr,
+    startPrice: startPriceStr,
+    highestPrice: highestPriceStr,
+    totalBrackets: totalBracketsStr,
+  } = params;
+
+  //  Working with Decimals for enhanced precision
+  const lowestPrice = new Decimal(lowestPriceStr);
+  const startPrice = new Decimal(startPriceStr);
+  const highestPrice = new Decimal(highestPriceStr);
+  const totalBrackets = Number(totalBracketsStr);
+
+  const stepSizeAsMultiplier = highestPrice
+    .div(lowestPrice)
+    .pow(ONE_DECIMAL.div(totalBrackets));
+
+  // Same rounding as default Math.round
+  Decimal.set({ rounding: Decimal.ROUND_HALF_CEIL });
+
+  let quoteTokenBrackets = startPrice
+    .div(lowestPrice)
+    .ln()
+    .div(stepSizeAsMultiplier.ln())
+    // round to nearest integer
+    .round()
+    // will work with integers from now on
+    .toNumber();
+
+  if (quoteTokenBrackets > totalBrackets) {
+    quoteTokenBrackets = totalBrackets;
+  } else if (quoteTokenBrackets < 0) {
+    quoteTokenBrackets = 0;
+  }
+
+  return {
+    baseTokenBrackets: totalBrackets - quoteTokenBrackets,
+    quoteTokenBrackets,
+  };
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import Decimal from "decimal.js";
+
 export enum Network {
   mainnet = 1,
   ropsten = 3,
@@ -20,3 +22,5 @@ export const SAFE_ENDPOINT_URL =
   SAFE_ENDPOINT_URLS[Network[NETWORK]] || SAFE_ENDPOINT_URLS[Network.rinkeby];
 
 export const DEFAULT_INPUT_WIDTH = "130px";
+
+export const ONE_DECIMAL = new Decimal("1");

--- a/test/dummy.test.ts
+++ b/test/dummy.test.ts
@@ -1,3 +1,0 @@
-test("dummy", () => {
-  expect(true).toBeTruthy();
-});

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,0 +1,4 @@
+module.exports = (): void => {
+  process.env.NETWORK = "rinkeby";
+  process.env.INFURA_API_KEY = "213kldjalpi";
+};

--- a/test/utils/calculateBrackets.test.ts
+++ b/test/utils/calculateBrackets.test.ts
@@ -1,0 +1,74 @@
+import { Params, calculateBrackets } from "utils/calculateBrackets";
+import clone from "lodash/clone";
+
+const baseParams: Params = {
+  lowestPrice: "0.8",
+  startPrice: "1",
+  highestPrice: "1.2",
+  totalBrackets: "3",
+};
+test("totalBrackets == 0", () => {
+  const params = clone(baseParams);
+  params.totalBrackets = "0";
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 0,
+    quoteTokenBrackets: 0,
+  });
+});
+test("totalBrackets == 1", () => {
+  const params = clone(baseParams);
+  params.totalBrackets = "1";
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 0,
+    quoteTokenBrackets: 1,
+  });
+});
+test("even brackets", () => {
+  const params = clone(baseParams);
+  params.totalBrackets = "2";
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 1,
+    quoteTokenBrackets: 1,
+  });
+});
+test("odd brackets", () => {
+  const params = clone(baseParams);
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 1,
+    quoteTokenBrackets: 2,
+  });
+});
+test("lowestPrice == startPrice", () => {
+  const params = clone(baseParams);
+  params.startPrice = params.lowestPrice;
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 3,
+    quoteTokenBrackets: 0,
+  });
+});
+test("startPrice == highestPrice", () => {
+  const params = clone(baseParams);
+  params.startPrice = params.highestPrice;
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 0,
+    quoteTokenBrackets: 3,
+  });
+});
+test("startPrice == bracket boundary", () => {
+  const params = clone(baseParams);
+  // value manually calculated:
+  // pow(highestPrice/lowestPrice, 1/totalBrackets) * lowestPrice
+  // pow(1.2/0.8, 1/3) * 0.8
+  params.startPrice = "0.915771394";
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 2,
+    quoteTokenBrackets: 1,
+  });
+});


### PR DESCRIPTION
# Description

Closes #70 

Added proper bracket calculation, same as used on `dex-liquidity` scripts

- To calculate the brackets, is required to have all prices and total brackets inputs filled

![screenshot_2020-09-25_14-47-20](https://user-images.githubusercontent.com/43217/94318723-fe22c180-ff3d-11ea-9a9d-97084c18e5c1.png)


# To Test
- [ ] Open CMM app
- [ ] Play around with prices and brackets
- [ ] Deploy strategy and verify brackets funding match displayed values

# Background

N/A

