### PR TITLE
Fix price estimation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21724,6 +21724,14 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
+    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "final-form-calculate": "^1.3.2",
     "lodash": "^4.17.20",
     "moment": "^2.27.0",
+    "node-cache": "^5.1.2",
     "path-to-regexp": "^1.7.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/hooks/useGetPrice.ts
+++ b/src/hooks/useGetPrice.ts
@@ -112,7 +112,8 @@ export function useGetPrice(params: Params): Result {
           }
         }
 
-        cache.set(cacheKey, price);
+        // only store on cache if not `null`
+        price && cache.set(cacheKey, price);
       } catch (e) {
         const msg = `Failed to fetch price from '${source}' for '${baseToken.symbol}'/'${quoteToken.symbol}' pair`;
         console.error(msg, e);

--- a/src/hooks/useGetPrice.ts
+++ b/src/hooks/useGetPrice.ts
@@ -49,6 +49,14 @@ export function useGetPrice(params: Params): Result {
   > => {
     const { source, baseToken, quoteToken } = params;
 
+    // Race condition.
+    // Might be that one token is updated before the other, resulting on both
+    // base and quote being the same.
+    // We don't want to query the price of a token against itself.
+    if (baseToken.address === quoteToken.address) {
+      return;
+    }
+
     setIsLoading(true);
     setError("");
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -27,3 +27,5 @@ export const ONE_DECIMAL = new Decimal("1");
 
 export const MINIMUM_BRACKETS = 1;
 export const MAXIMUM_BRACKETS = 10;
+
+export const PRICE_CACHE_TIME = 30; // in seconds


### PR DESCRIPTION
# Description

- Fixing issue with price sometimes being set to `1`
- Caching price estimation for 30s
- Using inverted price for a pair if opposite price is available on cache.
  Example: 
    - Price WETH/USDC pair not on cache neither is USDC/WETH. Fetch it => `435.84...` store on cache for 30s
    - Price for USDC/WETH pair not on cache, WETH/USDC is! => `1 / 435.84...` = `0.02294...`

# To Test
Start app, pick two tokens

- [ ] Price should load
- [ ] Switch between tokens, there should be no load (for 30s)
- [ ] There should not be a price of `1` (unless two tokens have exactly the same price, which is unlikely)

# Background

N/A

