### PR TITLE
Task/Chore: Add linting for Typescript files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,5 +29,30 @@
         "additionalHooks": "useRecoilCallback"
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "env": { "browser": true, "es6": true, "node": true },
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "ecmaFeatures": { "jsx": true },
+        "ecmaVersion": 2020,
+        "sourceType": "module",
+        "project": "./tsconfig.json"
+      },
+      "extends": [
+        "plugin:@typescript-eslint/recommended",
+        "plugin:react/recommended",
+        "plugin:react-hooks/recommended",
+        "prettier/@typescript-eslint",
+        "plugin:prettier/recommended"
+      ],
+      "plugins": ["react", "@typescript-eslint"],
+      "settings": { "react": { "version": "detect" } },
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off" // one day
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,6 +1478,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@chainlink/contracts-0.0.9": {
+      "version": "npm:@chainlink/contracts@0.0.9",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.9.tgz",
+      "integrity": "sha512-bI97GItkgoViPNhJT9EDf/i33gMwpQj4MywV6IqMStKCoPrUkrTpx6Tt0Knhf73U8zh4qcY2+hoQ9Yqr8gLUqg==",
+      "requires": {
+        "@truffle/contract": "^4.2.6",
+        "ethers": "^4.0.45"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1830,7 +1839,7 @@
       }
     },
     "@gnosis.pm/dex-liquidity-provision": {
-      "version": "github:gnosis/dex-liquidity-provision#ffb9e5f112f2099a1c6e87f1e32fff456c50270c",
+      "version": "github:gnosis/dex-liquidity-provision#51503a9c680836a70491dfb5576a8d3c5ff1cadd",
       "from": "github:gnosis/dex-liquidity-provision#fix/add-withdraw-helper-to-wrapper",
       "requires": {
         "@gnosis.pm/dex-contracts": "^0.4.2",
@@ -22202,6 +22211,11 @@
       "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.5.1.tgz",
       "integrity": "sha512-oCGtQPLOou4su76IMr4XXJavy9a8OZmAXeUZ8diOdFznlL/mlkIlYr7wajqCzH4S47nlKPS7m0+a2nilCTpVPQ=="
     },
+    "openzeppelin-solidity-2.3.0": {
+      "version": "npm:openzeppelin-solidity@2.3.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -27083,15 +27097,6 @@
         "web3-utils": "1.2.2"
       },
       "dependencies": {
-        "@chainlink/contracts-0.0.9": {
-          "version": "npm:@chainlink/contracts@0.0.9",
-          "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.9.tgz",
-          "integrity": "sha512-bI97GItkgoViPNhJT9EDf/i33gMwpQj4MywV6IqMStKCoPrUkrTpx6Tt0Knhf73U8zh4qcY2+hoQ9Yqr8gLUqg==",
-          "requires": {
-            "@truffle/contract": "^4.2.6",
-            "ethers": "^4.0.45"
-          }
-        },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -27111,11 +27116,6 @@
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
-        },
-        "openzeppelin-solidity-2.3.0": {
-          "version": "npm:openzeppelin-solidity@2.3.0",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
         },
         "web3-utils": {
           "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^14.0.27",
     "@types/react": "^16.9.46",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
-    "@typescript-eslint/parser": "^3.9.0",
+    "@typescript-eslint/parser": "^3.10.1",
     "@welldone-software/why-did-you-render": "^5.0.0-alpha.2",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.3.0",
@@ -107,7 +107,7 @@
     }
   },
   "lint-staged": {
-    "*.js": [
+    "*.{js,ts,tsx,jsx}": [
       "eslint --fix"
     ]
   }

--- a/src/api/safe/findPendingStrategiesForOwner.ts
+++ b/src/api/safe/findPendingStrategiesForOwner.ts
@@ -1,7 +1,7 @@
 import { Web3Context } from "types";
 import PendingStrategy from "logic/pendingStrategy";
 
-import { getPendingTransactions } from "api/safe"
+import { getPendingTransactions } from "api/safe";
 
 const findPendingStrategiesForOwner = async (
   context: Web3Context
@@ -11,12 +11,14 @@ const findPendingStrategiesForOwner = async (
   } = context;
 
   const pendingSafeTransactions = await getPendingTransactions(owner);
-  
+
   const strategies: PendingStrategy[] = await Promise.all(
     pendingSafeTransactions
-      .filter((pendingSafeTransaction : any) => PendingStrategy.isPendingStrategyTx(pendingSafeTransaction))
+      .filter((pendingSafeTransaction: any) =>
+        PendingStrategy.isPendingStrategyTx(pendingSafeTransaction)
+      )
       .map(
-        async (pendingSafeTransaction : any): Promise<PendingStrategy> => {
+        async (pendingSafeTransaction: any): Promise<PendingStrategy> => {
           const strategy = new PendingStrategy(pendingSafeTransaction);
 
           await strategy.findFromPendingTransactions(context);

--- a/src/api/safe/index.ts
+++ b/src/api/safe/index.ts
@@ -6,7 +6,7 @@ if (!SAFE_ENDPOINT_URL) {
   );
 }
 
-export const getTransactions = async (safeAddress) : Promise<any[]> => {
+export const getTransactions = async (safeAddress: string): Promise<any[]> => {
   const response = await fetch(
     `${SAFE_ENDPOINT_URL}/api/v1/safes/${safeAddress}/transactions`
   );
@@ -16,20 +16,21 @@ export const getTransactions = async (safeAddress) : Promise<any[]> => {
   return txs.results;
 };
 
-export const getBalances = async (safeAddress) : Promise<any> => {
+export const getBalances = async (safeAddress: string): Promise<any> => {
   const response = await fetch(
     `${SAFE_ENDPOINT_URL}/api/v1/safes/${safeAddress}/balances`
   );
   return response.json();
 };
 
-
-export const getPendingTransactions = async (safeAddress) : Promise<any[]> => {
+export const getPendingTransactions = async (
+  safeAddress: string
+): Promise<any[]> => {
   const requestSafe = await fetch(
     `${SAFE_ENDPOINT_URL}/api/v1/safes/${safeAddress}/`
-  )
+  );
   const responseSafe = await requestSafe.json();
-  
+
   const requestTxs = await fetch(
     `${SAFE_ENDPOINT_URL}/api/v1/safes/${safeAddress}/transactions?executed=false&nonce__gte=${responseSafe.nonce}`
   );

--- a/src/api/utils/dexImports.ts
+++ b/src/api/utils/dexImports.ts
@@ -1,4 +1,4 @@
-import tradingHelperInit from "@gnosis.pm/dex-liquidity-provision/scripts/utils/trading_strategy_helpers"
+import tradingHelperInit from "@gnosis.pm/dex-liquidity-provision/scripts/utils/trading_strategy_helpers";
 import calcFleetAddressInit from "@gnosis.pm/dex-liquidity-provision/scripts/utils/calculate_fleet_addresses";
 import withdrawWrapperInit from "@gnosis.pm/dex-liquidity-provision/scripts/wrapper/withdraw";
 
@@ -6,28 +6,37 @@ import makeFakeArtifacts from "utils/makeFakeArtifacts";
 import { Web3Context } from "types";
 
 let tradingHelperInstance;
-export const importTradingStrategyHelpers = (context : Web3Context) : any => {
+export const importTradingStrategyHelpers = (context: Web3Context): any => {
   if (!tradingHelperInstance) {
-    tradingHelperInstance = tradingHelperInit(context.instance, makeFakeArtifacts(context));
+    tradingHelperInstance = tradingHelperInit(
+      context.instance,
+      makeFakeArtifacts(context)
+    );
   }
 
   return tradingHelperInstance;
-}
+};
 
 let calcFleetAddrInstance;
-export const importCalculateFleetAddresses = (context : Web3Context) : any => {
+export const importCalculateFleetAddresses = (context: Web3Context): any => {
   if (!calcFleetAddrInstance) {
-    calcFleetAddrInstance = calcFleetAddressInit(context.instance, makeFakeArtifacts(context));
+    calcFleetAddrInstance = calcFleetAddressInit(
+      context.instance,
+      makeFakeArtifacts(context)
+    );
   }
 
   return calcFleetAddrInstance;
-}
+};
 
 let withdrawWrapperInstance;
-export const importWithdrawWrapper = (context : Web3Context) : any => {
+export const importWithdrawWrapper = (context: Web3Context): any => {
   if (!withdrawWrapperInstance) {
-    withdrawWrapperInstance = withdrawWrapperInit(context.instance, makeFakeArtifacts(context));
+    withdrawWrapperInstance = withdrawWrapperInit(
+      context.instance,
+      makeFakeArtifacts(context)
+    );
   }
 
   return withdrawWrapperInstance;
-}
+};

--- a/src/components/basic/display/MarketPrice/index.tsx
+++ b/src/components/basic/display/MarketPrice/index.tsx
@@ -12,7 +12,7 @@ export interface Props {
   setError?: (msg?: string) => void;
 }
 
-function component(props: Props): JSX.Element {
+function UMarketPrice(props: Props): JSX.Element {
   const { baseTokenAddress, quoteTokenAddress, setError, onPriceClick } = props;
 
   // TODO: handle error
@@ -30,11 +30,11 @@ function component(props: Props): JSX.Element {
     if (onPriceClick && price && !isLoading) {
       onPriceClick(price.toString());
     }
-  }, [price, isLoading]);
+  }, [price, isLoading, onPriceClick]);
 
   useEffect(() => {
     setError && setError(error);
-  }, [error]);
+  }, [error, setError]);
 
   return (
     <MarketPriceViewer
@@ -47,4 +47,4 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const MarketPrice: typeof component = memo(component);
+export const MarketPrice: typeof UMarketPrice = memo(UMarketPrice);

--- a/src/components/basic/display/MarketPrice/viewer.tsx
+++ b/src/components/basic/display/MarketPrice/viewer.tsx
@@ -23,7 +23,7 @@ export interface MarketPriceViewerProps {
   onClick?: () => void;
 }
 
-function component(props: MarketPriceViewerProps): JSX.Element {
+function UMarketPriceViewer(props: MarketPriceViewerProps): JSX.Element {
   const {
     price,
     isPriceLoading,
@@ -59,4 +59,6 @@ function component(props: MarketPriceViewerProps): JSX.Element {
   return <SubtextAmount subtext="Market price:" amount={amount} inline />;
 }
 
-export const MarketPriceViewer = memo(component);
+export const MarketPriceViewer: typeof UMarketPriceViewer = memo(
+  UMarketPriceViewer
+);

--- a/src/components/basic/display/Message/index.tsx
+++ b/src/components/basic/display/Message/index.tsx
@@ -5,8 +5,10 @@ import { Icon, Text } from "@gnosis.pm/safe-react-components";
 
 import { theme } from "theme";
 
+type TypeStrings = "error" | "warning";
+
 export interface Props {
-  type: "error" | "warning";
+  type: TypeStrings;
   label: string;
   children: React.ReactNode;
 }
@@ -37,7 +39,9 @@ const Wrapper = styled.div<Props>`
   }
 `;
 
-const UMessage: React.FC<Props> = ({ type, label, children }) => {
+const UMessage: React.FC<Props> = (props: Props) => {
+  const { type, label, children } = props;
+
   const msgBody = useMemo((): React.ReactNode => {
     if (!children) {
       return children;
@@ -67,12 +71,6 @@ const UMessage: React.FC<Props> = ({ type, label, children }) => {
       {msgBody}
     </Wrapper>
   );
-};
-
-UMessage.propTypes = {
-  label: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
 };
 
 export const Message: typeof UMessage = memo(UMessage);

--- a/src/components/basic/display/Message/index.tsx
+++ b/src/components/basic/display/Message/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useMemo } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Icon, Text } from "@gnosis.pm/safe-react-components";
 
@@ -36,9 +37,7 @@ const Wrapper = styled.div<Props>`
   }
 `;
 
-const component: React.FC<Props> = (props) => {
-  const { type, label, children } = props;
-
+const UMessage: React.FC<Props> = ({ type, label, children }) => {
   const msgBody = useMemo((): React.ReactNode => {
     if (!children) {
       return children;
@@ -70,4 +69,10 @@ const component: React.FC<Props> = (props) => {
   );
 };
 
-export const Message = memo(component);
+UMessage.propTypes = {
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export const Message: typeof UMessage = memo(UMessage);

--- a/src/components/basic/display/SubtextAmount/index.tsx
+++ b/src/components/basic/display/SubtextAmount/index.tsx
@@ -31,7 +31,7 @@ export interface Props extends WrapperProps {
   amount: string | React.ReactElement;
 }
 
-function component(props: Props): JSX.Element {
+function USubtextAmount(props: Props): JSX.Element {
   const { subtext, amount, inline } = props;
 
   return (
@@ -46,4 +46,4 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const SubtextAmount: typeof component = memo(component);
+export const SubtextAmount: typeof USubtextAmount = memo(USubtextAmount);

--- a/src/components/basic/display/TextWithTooltip/TextWithTooltip.stories.tsx
+++ b/src/components/basic/display/TextWithTooltip/TextWithTooltip.stories.tsx
@@ -36,5 +36,5 @@ export const ComponentAsText = Template.bind({});
 ComponentAsText.args = {
   ...Default.args,
   color: "error",
-  children: <span>I'm a component</span>,
+  children: <span>I&apos;m a component</span>,
 };

--- a/src/components/basic/display/TokenDisplay/index.tsx
+++ b/src/components/basic/display/TokenDisplay/index.tsx
@@ -22,7 +22,7 @@ export interface Props {
  * - display shortened address with link to Etherscan when symbol/name not available
  * - add support for displaying token images
  */
-function component(props: Props): JSX.Element {
+function UTokenDisplay(props: Props): JSX.Element {
   const { token, size, color } = props;
 
   // TODO: handle error
@@ -41,4 +41,4 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const TokenDisplay = memo(component);
+export const TokenDisplay: typeof UTokenDisplay = memo(UTokenDisplay);

--- a/src/components/basic/inputs/BracketsInput/index.tsx
+++ b/src/components/basic/inputs/BracketsInput/index.tsx
@@ -26,7 +26,7 @@ const Wrapper = styled(NumberInput)`
   }
 `;
 
-export interface Props extends Omit<NumberInputProps, "type"> {}
+export type Props = Omit<NumberInputProps, "type">;
 
 export const BracketsInput = (props: Props): JSX.Element => {
   const { value } = props;

--- a/src/components/basic/inputs/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/basic/inputs/ButtonLink/ButtonLink.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { ButtonLink, Props } from ".";
 import { action } from "@storybook/addon-actions";

--- a/src/components/basic/inputs/ButtonLink/index.tsx
+++ b/src/components/basic/inputs/ButtonLink/index.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled(SRCButtonLink)`
   }
 `;
 
-export interface Props extends ComponentProps<typeof SRCButtonLink> {}
+export type Props = ComponentProps<typeof SRCButtonLink>;
 
 export const ButtonLink = (props: Props): ReturnType<typeof SRCButtonLink> => (
   <Wrapper {...props} />

--- a/src/components/basic/inputs/FundingInput/Label.tsx
+++ b/src/components/basic/inputs/FundingInput/Label.tsx
@@ -17,7 +17,7 @@ interface Props {
   disabled?: boolean;
 }
 
-function component(props: Props): JSX.Element {
+function ULabel(props: Props): JSX.Element {
   const { onClick, error, disabled } = props;
   return (
     <Wrapper {...props}>
@@ -42,4 +42,4 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const Label: typeof component = memo(component);
+export const Label: typeof ULabel = memo(ULabel);

--- a/src/components/basic/inputs/FundingInput/PerBracketAmount.tsx
+++ b/src/components/basic/inputs/FundingInput/PerBracketAmount.tsx
@@ -14,7 +14,7 @@ export interface Props {
   tokenAddress: string;
 }
 
-function component(props: Props): JSX.Element {
+function UPerBracketAmount(props: Props): JSX.Element {
   const { totalAmount, brackets = 0, tokenAddress } = props;
 
   const { tokenDetails } = useTokenDetails(tokenAddress);
@@ -52,4 +52,6 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const PerBracketAmount: typeof component = memo(component);
+export const PerBracketAmount: typeof UPerBracketAmount = memo(
+  UPerBracketAmount
+);

--- a/src/components/basic/inputs/Link/Link.stories.tsx
+++ b/src/components/basic/inputs/Link/Link.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { action } from "@storybook/addon-actions";
 

--- a/src/components/basic/inputs/NumberInput/index.tsx
+++ b/src/components/basic/inputs/NumberInput/index.tsx
@@ -32,7 +32,7 @@ export const NumberInput = (props: Props): JSX.Element => {
         event.preventDefault();
       }
     },
-    []
+    [onChange]
   );
 
   return (

--- a/src/components/basic/inputs/TextFieldWithCustomLabel/TextFieldWithCustomLabel.stories.tsx
+++ b/src/components/basic/inputs/TextFieldWithCustomLabel/TextFieldWithCustomLabel.stories.tsx
@@ -9,7 +9,7 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-const onSubmit = (e: React.FormEvent) => e.preventDefault();
+const onSubmit = (e: React.FormEvent): void => e.preventDefault();
 
 export const textFieldData = {
   id: "fieldId",
@@ -27,7 +27,7 @@ export const textFieldData = {
   ),
 };
 
-export const Default = () => {
+export const Default: React.FC = () => {
   const [value, setValue] = useState("");
   return (
     <form noValidate autoComplete="off" onSubmit={onSubmit}>
@@ -40,7 +40,7 @@ export const Default = () => {
   );
 };
 
-export const CustomWidth = () => {
+export const CustomWidth: React.FC = () => {
   const [value, setValue] = useState("");
   return (
     <form noValidate autoComplete="off" onSubmit={onSubmit}>
@@ -54,7 +54,7 @@ export const CustomWidth = () => {
   );
 };
 
-export const VeryLongValue = () => {
+export const VeryLongValue: React.FC = () => {
   const [value, setValue] = useState(
     "564897654165765132578645325746146254890849084089"
   );
@@ -69,7 +69,7 @@ export const VeryLongValue = () => {
   );
 };
 
-export const WithAdornmentsAndLongInput = () => {
+export const WithAdornmentsAndLongInput: React.FC = () => {
   const [value, setValue] = useState(
     "38798749879879879543574.2468165735484657465"
   );
@@ -86,7 +86,7 @@ export const WithAdornmentsAndLongInput = () => {
   );
 };
 
-export const WithErrorMessage = () => {
+export const WithErrorMessage: React.FC = () => {
   const [value, setValue] = useState("kajsdla");
   return (
     <form noValidate autoComplete="off" onSubmit={onSubmit}>
@@ -100,7 +100,7 @@ export const WithErrorMessage = () => {
   );
 };
 
-export const WithErrorHighlightWithoutMessage = () => {
+export const WithErrorHighlightWithoutMessage: React.FC = () => {
   const [value, setValue] = useState("");
   return (
     <form noValidate autoComplete="off" onSubmit={onSubmit}>
@@ -114,7 +114,7 @@ export const WithErrorHighlightWithoutMessage = () => {
   );
 };
 
-export const WithWarningHighlight = () => {
+export const WithWarningHighlight: React.FC = () => {
   const [value, setValue] = useState("");
   return (
     <form noValidate autoComplete="off" onSubmit={onSubmit}>

--- a/src/components/basic/inputs/TokenSelector/index.tsx
+++ b/src/components/basic/inputs/TokenSelector/index.tsx
@@ -24,7 +24,7 @@ export interface Props {
  * Deals with hooks and state.
  * To be used externally in other components
  */
-function component(props: Props): JSX.Element {
+function UTokenSelector(props: Props): JSX.Element {
   const { selectedTokenAddress, setError, ...rest } = props;
 
   const tokenList = useTokenList();
@@ -36,7 +36,7 @@ function component(props: Props): JSX.Element {
   // probably better when adding validation
   useEffect((): void => {
     setError && setError(error);
-  }, [error]);
+  }, [error, setError]);
 
   const tokenDetails = useMemo(
     (): TokenDetails | undefined =>
@@ -61,4 +61,4 @@ function component(props: Props): JSX.Element {
   );
 }
 
-export const TokenSelector: typeof component = memo(component);
+export const TokenSelector: typeof UTokenSelector = memo(UTokenSelector);

--- a/src/components/basic/inputs/TokenSelector/viewer.tsx
+++ b/src/components/basic/inputs/TokenSelector/viewer.tsx
@@ -41,7 +41,7 @@ export interface TokenSelectorViewerProps
   tokenDetails?: TokenDetails;
 }
 
-function component(props: TokenSelectorViewerProps): JSX.Element {
+function UTokenSelectorViewer(props: TokenSelectorViewerProps): JSX.Element {
   const {
     label,
     tooltip,
@@ -83,4 +83,6 @@ function component(props: TokenSelectorViewerProps): JSX.Element {
   );
 }
 
-export const TokenSelectorViewer = memo(component);
+export const TokenSelectorViewer: typeof UTokenSelectorViewer = memo(
+  UTokenSelectorViewer
+);

--- a/src/components/pages/deploy/DeployForm.tsx
+++ b/src/components/pages/deploy/DeployForm.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useCallback, useContext } from "react";
+import PropTypes from "prop-types";
 import {
   FormApi,
   FormState,
@@ -43,7 +44,7 @@ function Warnings({
         warn: +values.lowestPrice < 1 ? "More than 1, please" : undefined,
       });
     },
-    []
+    [setFieldData]
   );
 
   return <FormSpy subscription={{ values: true }} onChange={handleWarnings} />;
@@ -58,7 +59,7 @@ const validateFactory = (
   const lowestPrice = Number(values.lowestPrice);
   const startPrice = Number(values.startPrice);
   const highestPrice = Number(values.highestPrice);
-  const totalBrackets = Number(values.totalBrackets);
+  // const totalBrackets = Number(values.totalBrackets);
 
   // this is a calculated field where we store two integers in a single string
   const baseTokenBrackets = getBracketValue(values.calculatedBrackets, "base");
@@ -190,7 +191,7 @@ function priceToBn(price: string): BN {
   return new BN(new Decimal(price).mul(1e18).toString());
 }
 
-const component: React.FC = ({ children }) => {
+const UDeployForm: React.FC = ({ children }) => {
   const context = useContext(Web3Context) as Web3ContextType;
   const { getErc20Details } = context;
 
@@ -262,7 +263,7 @@ const component: React.FC = ({ children }) => {
         };
       }
     },
-    [getErc20Details]
+    [getErc20Details, context]
   );
 
   return (
@@ -283,4 +284,8 @@ const component: React.FC = ({ children }) => {
   );
 };
 
-export const DeployForm: typeof component = memo(component);
+UDeployForm.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const DeployForm: typeof UDeployForm = memo(UDeployForm);

--- a/src/components/pages/deploy/DeployPage.stories.tsx
+++ b/src/components/pages/deploy/DeployPage.stories.tsx
@@ -8,7 +8,7 @@ import {
   Return as UseDeployStrategyReturn,
 } from "hooks/useDeployStrategy";
 
-import { DeployPageViewer, Props } from "./viewer";
+import { DeployPageViewer } from "./viewer";
 import { DeployPage } from ".";
 import {
   baseTokenAddressAtom,
@@ -58,7 +58,7 @@ export default {
 
 // Viewer
 
-const Template = (args: Props): JSX.Element => {
+const Template = (args: any): JSX.Element => {
   const onSubmit = async (
     event: React.FormEvent<HTMLFormElement>
   ): Promise<void> => event.preventDefault();

--- a/src/components/pages/deploy/DeployPage.stories.tsx
+++ b/src/components/pages/deploy/DeployPage.stories.tsx
@@ -4,7 +4,7 @@ import Decimal from "decimal.js";
 import { Meta } from "@storybook/react";
 
 import {
-  Params as UseDeployStrategyParams,
+  // Params as UseDeployStrategyParams,
   Return as UseDeployStrategyReturn,
 } from "hooks/useDeployStrategy";
 
@@ -48,7 +48,7 @@ export default {
           ? new BN("9310293132123908088")
           : address === "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
           ? new BN("579127394283794127491")
-          : !!address
+          : address
           ? new BN("0")
           : null,
     }),
@@ -87,10 +87,11 @@ const TemplateContainer = (): JSX.Element => <DeployPage />;
 
 export const DefaultContainer = TemplateContainer.bind({});
 DefaultContainer.parameters = {
-  useDeployStrategy: (
-    params: UseDeployStrategyParams
-  ): UseDeployStrategyReturn => {
-    return async (): Promise<void> => {};
+  useDeployStrategy: (): // params: UseDeployStrategyParams
+  UseDeployStrategyReturn => {
+    return async (): Promise<void> => {
+      return;
+    };
   },
 };
 

--- a/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
+++ b/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
@@ -28,6 +28,4 @@ function UDeployStrategyButtonFragment(): JSX.Element {
   );
 }
 
-export const DeployStrategyButtonFragment: typeof UDeployStrategyButtonFragment = memo(
-  UDeployStrategyButtonFragment
-);
+export const DeployStrategyButtonFragment = memo(UDeployStrategyButtonFragment);

--- a/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
+++ b/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
@@ -10,7 +10,7 @@ const StyledButton = styled(Button)`
   font-weight: bold;
 `;
 
-function component(): JSX.Element {
+function UDeployStrategyButtonFragment(): JSX.Element {
   const { invalid, pristine, submitting } = useFormState({
     subscription: { invalid: true, pristine: true, submitting: true },
   });
@@ -28,4 +28,6 @@ function component(): JSX.Element {
   );
 }
 
-export const DeployStrategyButtonFragment = memo(component);
+export const DeployStrategyButtonFragment: typeof UDeployStrategyButtonFragment = memo(
+  UDeployStrategyButtonFragment
+);

--- a/src/components/pages/deploy/ErrorMessagesFragment.tsx
+++ b/src/components/pages/deploy/ErrorMessagesFragment.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
   }
 `;
 
-function component(): JSX.Element {
+function UErrorMessageFragment(): JSX.Element {
   const { errors = {}, touched = {}, submitErrors = {} } = useFormState({
     subscription: { errors: true, touched: true, submitErrors: true },
   });
@@ -43,4 +43,6 @@ function component(): JSX.Element {
   );
 }
 
-export const ErrorMessagesFragment = memo(component);
+export const ErrorMessagesFragment: typeof UErrorMessageFragment = memo(
+  UErrorMessageFragment
+);

--- a/src/components/pages/deploy/ErrorMessagesFragment.tsx
+++ b/src/components/pages/deploy/ErrorMessagesFragment.tsx
@@ -43,6 +43,4 @@ function UErrorMessageFragment(): JSX.Element {
   );
 }
 
-export const ErrorMessagesFragment: typeof UErrorMessageFragment = memo(
-  UErrorMessageFragment
-);
+export const ErrorMessagesFragment = memo(UErrorMessageFragment);

--- a/src/components/pages/deploy/FormBackdrop.tsx
+++ b/src/components/pages/deploy/FormBackdrop.tsx
@@ -15,4 +15,4 @@ function UFormBackdrop(): JSX.Element {
   );
 }
 
-export const FormBackdrop: typeof UFormBackdrop = memo(UFormBackdrop);
+export const FormBackdrop = memo(UFormBackdrop);

--- a/src/components/pages/deploy/FormBackdrop.tsx
+++ b/src/components/pages/deploy/FormBackdrop.tsx
@@ -5,7 +5,7 @@ import { useFormState } from "react-final-form";
 
 const StyledBackdrop = withStyles(() => ({ root: { zIndex: 999 } }))(Backdrop);
 
-function component(): JSX.Element {
+function UFormBackdrop(): JSX.Element {
   const { submitting } = useFormState({ subscription: { submitting: true } });
 
   return (
@@ -15,4 +15,4 @@ function component(): JSX.Element {
   );
 }
 
-export const FormBackdrop = memo(component);
+export const FormBackdrop: typeof UFormBackdrop = memo(UFormBackdrop);

--- a/src/components/pages/deploy/MarketPriceFragment.tsx
+++ b/src/components/pages/deploy/MarketPriceFragment.tsx
@@ -38,6 +38,4 @@ function UMarketPriceFragment(): JSX.Element {
   );
 }
 
-export const MarketPriceFragment: typeof UMarketPriceFragment = memo(
-  UMarketPriceFragment
-);
+export const MarketPriceFragment = memo(UMarketPriceFragment);

--- a/src/components/pages/deploy/MarketPriceFragment.tsx
+++ b/src/components/pages/deploy/MarketPriceFragment.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
   align-self: center;
 `;
 
-function component(): JSX.Element {
+function UMarketPriceFragment(): JSX.Element {
   const {
     input: { value: baseTokenAddress },
   } = useField<string>("baseTokenAddress");
@@ -38,4 +38,6 @@ function component(): JSX.Element {
   );
 }
 
-export const MarketPriceFragment = memo(component);
+export const MarketPriceFragment: typeof UMarketPriceFragment = memo(
+  UMarketPriceFragment
+);

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -71,7 +71,7 @@ const onMaxClickFactory = (
   }
 };
 
-function component(): JSX.Element {
+function UPricesFragment(): JSX.Element {
   const totalInvestment = useRecoilValue(totalInvestmentAtom);
 
   const {
@@ -225,4 +225,4 @@ function component(): JSX.Element {
   );
 }
 
-export const PricesFragment = memo(component);
+export const PricesFragment: typeof UPricesFragment = memo(UPricesFragment);

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -225,4 +225,4 @@ function UPricesFragment(): JSX.Element {
   );
 }
 
-export const PricesFragment: typeof UPricesFragment = memo(UPricesFragment);
+export const PricesFragment = memo(UPricesFragment);

--- a/src/components/pages/deploy/SideBar.tsx
+++ b/src/components/pages/deploy/SideBar.tsx
@@ -102,7 +102,7 @@ const StyledAccordionDetails = withStyles({
   },
 })(AccordionDetails);
 
-function component(): JSX.Element {
+function USideBar(): JSX.Element {
   return (
     <Wrapper>
       <div>
@@ -144,4 +144,4 @@ function component(): JSX.Element {
   );
 }
 
-export const SideBar = memo(component);
+export const SideBar: typeof USideBar = memo(USideBar);

--- a/src/components/pages/deploy/SideBar.tsx
+++ b/src/components/pages/deploy/SideBar.tsx
@@ -144,4 +144,4 @@ function USideBar(): JSX.Element {
   );
 }
 
-export const SideBar: typeof USideBar = memo(USideBar);
+export const SideBar = memo(USideBar);

--- a/src/components/pages/deploy/TokenSelectorsFragment.tsx
+++ b/src/components/pages/deploy/TokenSelectorsFragment.tsx
@@ -57,6 +57,4 @@ function UTokenSelectorsFragment(): JSX.Element {
   );
 }
 
-export const TokenSelectorsFragment: typeof UTokenSelectorsFragment = memo(
-  UTokenSelectorsFragment
-);
+export const TokenSelectorsFragment = memo(UTokenSelectorsFragment);

--- a/src/components/pages/deploy/TokenSelectorsFragment.tsx
+++ b/src/components/pages/deploy/TokenSelectorsFragment.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled.div`
   }
 `;
 
-function component(): JSX.Element {
+function UTokenSelectorsFragment(): JSX.Element {
   const {
     mutators: { swapTokens },
   } = useForm();
@@ -57,4 +57,6 @@ function component(): JSX.Element {
   );
 }
 
-export const TokenSelectorsFragment = memo(component);
+export const TokenSelectorsFragment: typeof UTokenSelectorsFragment = memo(
+  UTokenSelectorsFragment
+);

--- a/src/components/pages/deploy/viewer.tsx
+++ b/src/components/pages/deploy/viewer.tsx
@@ -58,6 +58,4 @@ function UDeployPageViewer(): JSX.Element {
   );
 }
 
-export const DeployPageViewer: typeof UDeployPageViewer = memo(
-  UDeployPageViewer
-);
+export const DeployPageViewer = memo(UDeployPageViewer);

--- a/src/components/pages/deploy/viewer.tsx
+++ b/src/components/pages/deploy/viewer.tsx
@@ -40,7 +40,7 @@ const DeployWidget = styled.div`
   align-items: stretch;
 `;
 
-function component(): JSX.Element {
+function UDeployPageViewer(): JSX.Element {
   return (
     <PageLayout>
       <DeployForm>
@@ -58,4 +58,6 @@ function component(): JSX.Element {
   );
 }
 
-export const DeployPageViewer = memo(component);
+export const DeployPageViewer: typeof UDeployPageViewer = memo(
+  UDeployPageViewer
+);

--- a/src/hooks/useGetPrice.ts
+++ b/src/hooks/useGetPrice.ts
@@ -75,7 +75,7 @@ export function useGetPrice(params: Params): Result {
 
   useEffect((): void => {
     baseToken && quoteToken && getPrice({ source, baseToken, quoteToken });
-  }, [source, baseToken, quoteToken]);
+  }, [source, baseToken, quoteToken, getPrice]);
 
   return { price, isLoading, error };
 }

--- a/src/hooks/useTokenDetails.ts
+++ b/src/hooks/useTokenDetails.ts
@@ -32,7 +32,7 @@ export function useTokenDetails(token?: string): Return {
       }
     }
     fetchTokenDetails();
-  }, [token]);
+  }, [token, getErc20Details]);
 
   return { tokenDetails, isLoading, error };
 }

--- a/src/hooks/useWeb3Strategies.ts
+++ b/src/hooks/useWeb3Strategies.ts
@@ -1,52 +1,52 @@
-import { useCallback, useState, useEffect, useContext } from "react"
-import useInterval from "@use-it/interval"
+import { useCallback, useState, useEffect, useContext } from "react";
+import useInterval from "@use-it/interval";
 
-import getLogger from 'utils/logger';
+import getLogger from "utils/logger";
 
-import findStrategiesForOwner from 'api/web3/findStrategiesForOwner';
-import { Web3Context } from 'components/Web3Provider';
+import findStrategiesForOwner from "api/web3/findStrategiesForOwner";
+import { Web3Context } from "components/Web3Provider";
 
 import { Web3Context as Web3ContextType } from "types";
 
-const logger = getLogger('web3-strategy-hook');
+const logger = getLogger("web3-strategy-hook");
 
-const useWeb3Strategies = () : any => {
-  const [status, setStatus] = useState('LOADING');
+const useWeb3Strategies = (): any => {
+  const [status, setStatus] = useState("LOADING");
   const [isFetching, setIsFetching] = useState(false);
   const [strategies, setStrategies] = useState([]);
 
-  const context : Web3ContextType = useContext(Web3Context);
+  const context: Web3ContextType = useContext(Web3Context);
 
   const handleFindStrategies = useCallback(async () => {
     setIsFetching(true);
     try {
-      const strategies = await findStrategiesForOwner(context)
-      logger.log('Active strategies loaded via web3:', strategies)
-      setStatus('SUCCESS')
+      const strategies = await findStrategiesForOwner(context);
+      logger.log("Active strategies loaded via web3:", strategies);
+      setStatus("SUCCESS");
       setStrategies(strategies);
     } catch (err) {
-      setStatus('ERROR')
+      setStatus("ERROR");
       console.error(err);
     } finally {
       setIsFetching(false);
     }
-  }, [context])
+  }, [context]);
 
   useEffect(() => {
-    setStatus('LOADING');
-    handleFindStrategies()
-  }, [])
+    setStatus("LOADING");
+    handleFindStrategies();
+  }, [handleFindStrategies]);
 
   useInterval(() => {
     if (!isFetching) {
       handleFindStrategies();
     }
-  }, 10000)
+  }, 10000);
 
   return {
     status,
-    strategies
-  }
-}
+    strategies,
+  };
+};
 
 export default useWeb3Strategies;

--- a/src/logic/pendingStrategy.ts
+++ b/src/logic/pendingStrategy.ts
@@ -1,39 +1,44 @@
-import { Web3Context, TokenDetails } from 'types';
-import web3 from 'web3'
-import find from "lodash/find"
+import { Web3Context, TokenDetails } from "types";
+import web3 from "web3";
 
-import BN from 'bn.js';
-import Decimal from 'decimal.js';
+import BN from "bn.js";
+import Decimal from "decimal.js";
 
 const { toBN } = web3.utils;
 
-import { DecoderData, FundingDetails, calculateFundsFromTxData, pricesToRange, PriceRange } from "./utils/calculateFunds";
+import {
+  DecoderData,
+  FundingDetails,
+  calculateFundsFromTxData,
+  pricesToRange,
+  PriceRange,
+} from "./utils/calculateFunds";
 
 // const logger = getLogger('pending-strategy');
 
 class PendingStrategy {
-  transactionHash : string;
-  safeAddresses : string[];
-  bracketAddresses : string[];
+  transactionHash: string;
+  safeAddresses: string[];
+  bracketAddresses: string[];
   prices: Decimal[];
   nonce: number;
-  baseTokenId : number;
-  quoteTokenId : number;
-  baseTokenAddress : string;
-  quoteTokenAddress : string;
-  baseTokenDetails : TokenDetails;
-  quoteTokenDetails : TokenDetails;
-  baseFunding : Decimal;
-  quoteFunding : Decimal;
-  owner : string;
-  created : Date;
-  block : any;
-  transactionData : DecoderData;
+  baseTokenId: number;
+  quoteTokenId: number;
+  baseTokenAddress: string;
+  quoteTokenAddress: string;
+  baseTokenDetails: TokenDetails;
+  quoteTokenDetails: TokenDetails;
+  baseFunding: Decimal;
+  quoteFunding: Decimal;
+  owner: string;
+  created: Date;
+  block: any;
+  transactionData: DecoderData;
   priceRange: PriceRange;
   bracketsWithBaseToken: string[];
   bracketsWithQuoteToken: string[];
 
-  constructor(pendingStrategyTransaction : any) {
+  constructor(pendingStrategyTransaction: Record<string, any>) {
     this.transactionHash = pendingStrategyTransaction.safeTxHash;
     this.transactionData = pendingStrategyTransaction.dataDecoded;
     this.nonce = pendingStrategyTransaction.nonce;
@@ -43,23 +48,29 @@ class PendingStrategy {
   /**
    * Check if a transaction includes any indication that it is for a
    * pending strategy deployment and not something else.
-   * 
-   * @param pendingStrategyTransaction 
+   *
+   * @param pendingStrategyTransaction
    * @returns {Boolean} - Is the transaction for a strategy deployment?
    */
-  static isPendingStrategyTx(pendingStrategyTransaction : any) : Boolean {
+  static isPendingStrategyTx(
+    pendingStrategyTransaction: Record<string, any>
+  ): boolean {
     // FIXME: Sorry, this is awful. Needs to be fixed later.
     // Either implement the walkTransaction as a generic tx graph class, or come
     // up with something cooler.
     const txDataStr = JSON.stringify(pendingStrategyTransaction.dataDecoded);
 
     return (
-      txDataStr.includes("placeOrder") || txDataStr.includes("deployFleet") || txDataStr.includes("deployFleetWithNonce")
-    )
+      txDataStr.includes("placeOrder") ||
+      txDataStr.includes("deployFleet") ||
+      txDataStr.includes("deployFleetWithNonce")
+    );
   }
 
-  async findFromPendingTransactions(context : Web3Context) : Promise<void> {
-    const fundingDetails : FundingDetails = calculateFundsFromTxData(this.transactionData);
+  async findFromPendingTransactions(context: Web3Context): Promise<void> {
+    const fundingDetails: FundingDetails = calculateFundsFromTxData(
+      this.transactionData
+    );
     this.baseTokenId = fundingDetails.baseTokenId;
     this.quoteTokenId = fundingDetails.quoteTokenId;
 
@@ -75,12 +86,12 @@ class PendingStrategy {
       context.getArtifact("FleetFactory"),
       context.getArtifact("FleetFactoryDeterministic"),
       context.getArtifact("BatchExchange"),
-    ])
+    ]);
 
     const batchExchangeContract = await context.getDeployed("BatchExchange");
 
     if (this.baseTokenId == null || this.quoteTokenId == null) {
-      console.error(`Missing tokenIds for pending strategy`, this)
+      console.error(`Missing tokenIds for pending strategy`, this);
       return;
     }
 
@@ -95,32 +106,46 @@ class PendingStrategy {
     this.baseTokenAddress = tokenBaseAddress;
     this.quoteTokenAddress = tokenQuoteAddress;
 
-    this.baseTokenDetails = await context.getErc20Details(this.baseTokenAddress);
-    this.quoteTokenDetails = await context.getErc20Details(this.quoteTokenAddress);
+    this.baseTokenDetails = await context.getErc20Details(
+      this.baseTokenAddress
+    );
+    this.quoteTokenDetails = await context.getErc20Details(
+      this.quoteTokenAddress
+    );
 
-    const bracketsWithBaseToken = fundingDetails.bracketsByToken[this.baseTokenAddress];
-    const bracketsWithQuoteToken = fundingDetails.bracketsByToken[this.quoteTokenAddress]
+    const bracketsWithBaseToken =
+      fundingDetails.bracketsByToken[this.baseTokenAddress];
+    const bracketsWithQuoteToken =
+      fundingDetails.bracketsByToken[this.quoteTokenAddress];
 
     this.bracketsWithBaseToken = bracketsWithBaseToken || [];
     this.bracketsWithQuoteToken = bracketsWithQuoteToken || [];
-    
-    const baseFundingWei = Object.keys(bracketsWithBaseToken)
-      .reduce((acc : BN, bracketAddress : string) => {
-        console.log(bracketsWithBaseToken[bracketAddress].toString())
-        return acc.iadd(bracketsWithBaseToken[bracketAddress])
-      }, toBN(0));
+
+    const baseFundingWei = Object.keys(bracketsWithBaseToken).reduce(
+      (acc: BN, bracketAddress: string) => {
+        console.log(bracketsWithBaseToken[bracketAddress].toString());
+        return acc.iadd(bracketsWithBaseToken[bracketAddress]);
+      },
+      toBN(0)
+    );
     this.baseFunding = new Decimal(baseFundingWei.toString()).div(
       Math.pow(10, this.baseTokenDetails.decimals)
-    )
+    );
 
-    const quoteFundingWei = Object.keys(bracketsWithQuoteToken)
-      .reduce((acc : BN, bracketAddress : string) => {
-        return acc.iadd(bracketsWithQuoteToken[bracketAddress])
-      }, toBN(0));
+    const quoteFundingWei = Object.keys(bracketsWithQuoteToken).reduce(
+      (acc: BN, bracketAddress: string) => {
+        return acc.iadd(bracketsWithQuoteToken[bracketAddress]);
+      },
+      toBN(0)
+    );
     this.quoteFunding = new Decimal(quoteFundingWei.toString()).div(
       Math.pow(10, this.quoteTokenDetails.decimals)
-    )
-    this.priceRange = pricesToRange(this.prices, this.baseTokenDetails, this.quoteTokenDetails);
+    );
+    this.priceRange = pricesToRange(
+      this.prices,
+      this.baseTokenDetails,
+      this.quoteTokenDetails
+    );
   }
 }
 

--- a/src/logic/strategy.ts
+++ b/src/logic/strategy.ts
@@ -1,55 +1,59 @@
-import { Web3Context, TokenDetails } from 'types';
-import web3GLib from "web3"
-import Decimal from 'decimal.js';
+import { Web3Context, TokenDetails } from "types";
+import web3GLib from "web3";
+import Decimal from "decimal.js";
 
-import { calculateFundsFromEvents, pricesToRange, PriceRange } from "./utils/calculateFunds";
+import {
+  calculateFundsFromEvents,
+  pricesToRange,
+  PriceRange,
+} from "./utils/calculateFunds";
 
 const { toBN } = web3GLib.utils;
 
-let globalResolvedTokenPromises = {};
+const globalResolvedTokenPromises = {};
 
 export interface Bracket {
-  address : string;
-  events : any[];
+  address: string;
+  events: any[];
   deposits: DepositEvent[];
   withdrawRequests: WithdrawEvent[];
   withdraws: any[];
 }
 
 export interface DepositEvent {
-  amount : string; // BN string
-  token : string;
-  batchId : number;
+  amount: string; // BN string
+  token: string;
+  batchId: number;
 }
 
 export interface WithdrawEvent {
-  amount : string;
-  batchId : number;
-  created : Date;
+  amount: string;
+  batchId: number;
+  created: Date;
 }
 
 class Strategy {
-  transactionHash : string;
-  safeAddresses : string[];
-  brackets : Bracket[];
-  prices : Decimal[];
+  transactionHash: string;
+  safeAddresses: string[];
+  brackets: Bracket[];
+  prices: Decimal[];
   startBlockNumber: number;
-  baseTokenId : number;
-  quoteTokenId : number;
-  baseTokenAddress : string;
-  quoteTokenAddress : string;
-  baseTokenDetails : TokenDetails;
-  quoteTokenDetails : TokenDetails;
-  baseFunding : string;
-  quoteFunding : string;
-  owner : string;
-  created : Date;
-  block : any;
-  lastWithdrawRequestEvent : WithdrawEvent;
-  lastWithdrawClaimEvent : any;
+  baseTokenId: number;
+  quoteTokenId: number;
+  baseTokenAddress: string;
+  quoteTokenAddress: string;
+  baseTokenDetails: TokenDetails;
+  quoteTokenDetails: TokenDetails;
+  baseFunding: string;
+  quoteFunding: string;
+  owner: string;
+  created: Date;
+  block: any;
+  lastWithdrawRequestEvent: WithdrawEvent;
+  lastWithdrawClaimEvent: any;
   priceRange: PriceRange;
 
-  constructor(fleetDeployEvent : any) {
+  constructor(fleetDeployEvent: Record<string, any>) {
     this.transactionHash = fleetDeployEvent.transactionHash;
     this.startBlockNumber = fleetDeployEvent.blockNumber;
     this.safeAddresses = fleetDeployEvent.returnValues.fleet;
@@ -58,7 +62,7 @@ class Strategy {
     this.lastWithdrawClaimEvent = null;
   }
 
-  async fetchAllPossibleInfo(context : Web3Context) : Promise<void> {
+  async fetchAllPossibleInfo(context: Web3Context): Promise<void> {
     // Find creation date by block number
     this.block = await context.instance.eth.getBlock(this.startBlockNumber);
     this.created = new Date(this.block.timestamp * 1000);
@@ -68,81 +72,113 @@ class Strategy {
     // Find all placed orders, to determine the brackets, token pairs and funding
     const batchExchangeContract = await context.getDeployed("BatchExchange");
 
-    let orderBatchIds = [];
-    let withdrawRequestBlocks = {};
-    let allWithdrawClaims = [];
+    const orderBatchIds = [];
+    const withdrawRequestBlocks = {};
+    const allWithdrawClaims = [];
 
-    let allBracketOrderEvents = []
-    const brackets = await Promise.all(this.safeAddresses.map(async (bracketAddress) : Promise<Bracket> => {
-      // Bracket orders find the tokens used for the strategy
-      const bracketOrderEvents = await batchExchangeContract.getPastEvents("OrderPlacement", {
-        fromBlock: this.startBlockNumber-1,
-        filter: { owner: bracketAddress }
-      })
-
-      allBracketOrderEvents.push(...bracketOrderEvents);
-      
-      // Bracket Deposits find the funding used for the strategy
-      const bracketDepositEvents = await batchExchangeContract.getPastEvents("Deposit", {
-        fromBlock: this.startBlockNumber-1,
-        filter: { user: bracketAddress }
-      });
-
-      const withdrawClaims = await batchExchangeContract.getPastEvents("Withdraw", {
-        fromBlock: this.startBlockNumber-1,
-        filter: { user: bracketAddress }
-      })
-      
-      allWithdrawClaims.push(...withdrawClaims)
-
-      let withdrawRequestsWithBlock : WithdrawEvent[] = []
-      if (bracketDepositEvents[0]) {
-        const withdrawRequests = await batchExchangeContract.getPastEvents("WithdrawRequest", {
-          fromBlock: this.startBlockNumber-1,
-          filter: { batchId: bracketDepositEvents[0].batchId, user: bracketAddress }
-        });
-  
-        withdrawRequestsWithBlock = await Promise.all(
-          withdrawRequests.map(async (withdrawRequest) : Promise<WithdrawEvent> => {
-            if (!withdrawRequestBlocks[withdrawRequest.blockNumber]) {
-              withdrawRequestBlocks[withdrawRequest.blockNumber] = await context.instance.eth.getBlock(withdrawRequest.blockNumber);
+    const allBracketOrderEvents = [];
+    const brackets = await Promise.all(
+      this.safeAddresses.map(
+        async (bracketAddress): Promise<Bracket> => {
+          // Bracket orders find the tokens used for the strategy
+          const bracketOrderEvents = await batchExchangeContract.getPastEvents(
+            "OrderPlacement",
+            {
+              fromBlock: this.startBlockNumber - 1,
+              filter: { owner: bracketAddress },
             }
-  
-            return {
-              amount: withdrawRequest.returnValues.amount,
-              batchId: parseInt(withdrawRequest.returnValues.batchId, 10),
-              created: new Date(withdrawRequestBlocks[withdrawRequest.blockNumber].timestamp * 1000),
-            }
-          })
-        )  
-      }
+          );
 
-      const deposits = bracketDepositEvents
-        .map((event) : DepositEvent => {
-          return {
-            token: event.returnValues.token,
-            amount: event.returnValues.amount,
-            batchId: event.returnValues.batchId,
+          allBracketOrderEvents.push(...bracketOrderEvents);
+
+          // Bracket Deposits find the funding used for the strategy
+          const bracketDepositEvents = await batchExchangeContract.getPastEvents(
+            "Deposit",
+            {
+              fromBlock: this.startBlockNumber - 1,
+              filter: { user: bracketAddress },
+            }
+          );
+
+          const withdrawClaims = await batchExchangeContract.getPastEvents(
+            "Withdraw",
+            {
+              fromBlock: this.startBlockNumber - 1,
+              filter: { user: bracketAddress },
+            }
+          );
+
+          allWithdrawClaims.push(...withdrawClaims);
+
+          let withdrawRequestsWithBlock: WithdrawEvent[] = [];
+          if (bracketDepositEvents[0]) {
+            const withdrawRequests = await batchExchangeContract.getPastEvents(
+              "WithdrawRequest",
+              {
+                fromBlock: this.startBlockNumber - 1,
+                filter: {
+                  batchId: bracketDepositEvents[0].batchId,
+                  user: bracketAddress,
+                },
+              }
+            );
+
+            withdrawRequestsWithBlock = await Promise.all(
+              withdrawRequests.map(
+                async (withdrawRequest): Promise<WithdrawEvent> => {
+                  if (!withdrawRequestBlocks[withdrawRequest.blockNumber]) {
+                    withdrawRequestBlocks[
+                      withdrawRequest.blockNumber
+                    ] = await context.instance.eth.getBlock(
+                      withdrawRequest.blockNumber
+                    );
+                  }
+
+                  return {
+                    amount: withdrawRequest.returnValues.amount,
+                    batchId: parseInt(withdrawRequest.returnValues.batchId, 10),
+                    created: new Date(
+                      withdrawRequestBlocks[withdrawRequest.blockNumber]
+                        .timestamp * 1000
+                    ),
+                  };
+                }
+              )
+            );
           }
-        })
 
-      deposits.forEach(({ batchId }) : void => {
-        if (!orderBatchIds.includes(batchId)) {
-          orderBatchIds.push(batchId)
+          const deposits = bracketDepositEvents.map(
+            (event): DepositEvent => {
+              return {
+                token: event.returnValues.token,
+                amount: event.returnValues.amount,
+                batchId: event.returnValues.batchId,
+              };
+            }
+          );
+
+          deposits.forEach(({ batchId }): void => {
+            if (!orderBatchIds.includes(batchId)) {
+              orderBatchIds.push(batchId);
+            }
+          });
+
+          return {
+            address: bracketAddress,
+            events: bracketOrderEvents,
+            withdrawRequests: withdrawRequestsWithBlock,
+            withdraws: withdrawClaims,
+            deposits,
+          };
         }
-      })
-
-      return {
-        address: bracketAddress,
-        events: bracketOrderEvents,
-        withdrawRequests: withdrawRequestsWithBlock,
-        withdraws: withdrawClaims,
-        deposits,
-      }
-    }))
+      )
+    );
 
     if (allBracketOrderEvents.length > 0) {
-      const fundingDetails = calculateFundsFromEvents(allBracketOrderEvents, this.safeAddresses);
+      const fundingDetails = calculateFundsFromEvents(
+        allBracketOrderEvents,
+        this.safeAddresses
+      );
       this.baseTokenId = fundingDetails.baseTokenId;
       this.quoteTokenId = fundingDetails.quoteTokenId;
       this.prices = fundingDetails.bracketPrices;
@@ -153,31 +189,47 @@ class Strategy {
 
     if (this.baseTokenId != null) {
       if (!globalResolvedTokenPromises[this.baseTokenId]) {
-        globalResolvedTokenPromises[this.baseTokenId] = batchExchangeContract.methods.tokenIdToAddressMap(this.baseTokenId).call()
+        globalResolvedTokenPromises[
+          this.baseTokenId
+        ] = batchExchangeContract.methods
+          .tokenIdToAddressMap(this.baseTokenId)
+          .call();
       }
-      this.baseTokenAddress = await globalResolvedTokenPromises[this.baseTokenId]
-      this.baseTokenDetails = await context.getErc20Details(this.baseTokenAddress)
+      this.baseTokenAddress = await globalResolvedTokenPromises[
+        this.baseTokenId
+      ];
+      this.baseTokenDetails = await context.getErc20Details(
+        this.baseTokenAddress
+      );
     }
     if (this.quoteTokenId != null) {
       if (!globalResolvedTokenPromises[this.quoteTokenId]) {
-        globalResolvedTokenPromises[this.quoteTokenId] = batchExchangeContract.methods.tokenIdToAddressMap(this.quoteTokenId).call()
+        globalResolvedTokenPromises[
+          this.quoteTokenId
+        ] = batchExchangeContract.methods
+          .tokenIdToAddressMap(this.quoteTokenId)
+          .call();
       }
-      this.quoteTokenAddress = await globalResolvedTokenPromises[this.quoteTokenId]
-      this.quoteTokenDetails = await context.getErc20Details(this.quoteTokenAddress)
+      this.quoteTokenAddress = await globalResolvedTokenPromises[
+        this.quoteTokenId
+      ];
+      this.quoteTokenDetails = await context.getErc20Details(
+        this.quoteTokenAddress
+      );
     }
-    let baseFundingBn = toBN(0);
-    let quoteFundingBn = toBN(0);
+    const baseFundingBn = toBN(0);
+    const quoteFundingBn = toBN(0);
     if (brackets) {
-      brackets.forEach((bracket) : void => {
-        bracket.deposits.forEach((deposit) : void => {
+      brackets.forEach((bracket): void => {
+        bracket.deposits.forEach((deposit): void => {
           if (deposit.token === this.baseTokenAddress) {
-            baseFundingBn.iadd(toBN(deposit.amount)) 
+            baseFundingBn.iadd(toBN(deposit.amount));
           }
           if (deposit.token === this.quoteTokenAddress) {
-            quoteFundingBn.iadd(toBN(deposit.amount))
+            quoteFundingBn.iadd(toBN(deposit.amount));
           }
-        })
-      })  
+        });
+      });
     }
     this.baseFunding = baseFundingBn.toString();
     this.quoteFunding = quoteFundingBn.toString();
@@ -187,9 +239,13 @@ class Strategy {
 
     this.prices.sort((a, b) => {
       if (a.eq(b)) return 0;
-      return (a.gt(b) ? 1 : -1);
-    })
-    this.priceRange = pricesToRange(this.prices, this.baseTokenDetails, this.quoteTokenDetails);
+      return a.gt(b) ? 1 : -1;
+    });
+    this.priceRange = pricesToRange(
+      this.prices,
+      this.baseTokenDetails,
+      this.quoteTokenDetails
+    );
     this.brackets = brackets;
   }
 }

--- a/src/mock/mockHookContext.tsx
+++ b/src/mock/mockHookContext.tsx
@@ -1,41 +1,47 @@
-import React, { useContext } from 'react'
-import { BaseDecorators, Parameters } from '@storybook/addons'
+import React, { useContext } from "react";
+import { BaseDecorators, Parameters } from "@storybook/addons";
 
-const MockHookContext = React.createContext<Parameters>({})
+const MockHookContext = React.createContext<Parameters>({});
 
 /**
  * to mock useYourHook hook from src/hooks/useYourHook.ts
- * create a mock hook in src/mock/useYourHook.ts 
+ * create a mock hook in src/mock/useYourHook.ts
  * export const useYourHook = createMockHook('useYourHook', defaultValue?)
- * 
+ *
  * in *.stories.tsx
  * Story.parameter = {
  *  useYourHook: {whatever hook should return}
  * }
- * 
+ *
  * or
  * Story.parameter = {
  *  useYourHook: (...whatHookExpectsAsInput) => ({whatever hook should return})
  * }
  */
-export const createMockHook = <T extends (...args: any) => any>(name: string, defaultValue?: ReturnType<T>): T => {
+export const createMockHook = <T extends (...args: any) => any>(
+  name: string,
+  defaultValue?: ReturnType<T>
+): T => {
   return ((...args: any[]) => {
-    const ctx = useContext(MockHookContext)
-    const mockedHook = ctx[name]
+    const ctx = useContext(MockHookContext);
+    const mockedHook = ctx[name];
     // if parameters = {useYourHook: Function}, then execute with args
-    if (typeof mockedHook === 'function') {
-      const res = mockedHook(...args)
-      return res
+    if (typeof mockedHook === "function") {
+      const res = mockedHook(...args);
+      return res;
     }
     // if not Function, return as is or defaultValue if Nullable
-    return mockedHook ?? defaultValue
-  }) as T
-}
+    return mockedHook ?? defaultValue;
+  }) as T;
+};
 
-export const mockHookDecorator: BaseDecorators<JSX.Element>[0] = (Story, { parameters }) => {
+export const mockHookDecorator: BaseDecorators<JSX.Element>[0] = (
+  Story,
+  { parameters }
+) => {
   return (
     <MockHookContext.Provider value={parameters}>
       {Story()}
     </MockHookContext.Provider>
-  )
-}
+  );
+};

--- a/src/mock/useTokenDetails.ts
+++ b/src/mock/useTokenDetails.ts
@@ -1,9 +1,11 @@
 import { useTokenDetails as hook } from "hooks/useTokenDetails";
-import { TokenDetails } from "types";
+import { TokenDetails } from "../types";
 
 import { mockTokenDetails } from "./data";
 
-export const useTokenDetails: typeof hook = (token) => {
+export const useTokenDetails: typeof hook = (
+  token: string | TokenDetails
+): any => {
   let tokenDetails: null | TokenDetails;
 
   if (!token) {

--- a/src/routes/Strategies/Pending.js
+++ b/src/routes/Strategies/Pending.js
@@ -26,7 +26,7 @@ const Pending = () => {
 
   useEffect(() => {
     handleLoadPending();
-  }, []);
+  }, [handleLoadPending]);
 
   if (!strategies) {
     return (

--- a/src/utils/finalForm.ts
+++ b/src/utils/finalForm.ts
@@ -2,10 +2,10 @@ import type { MutableState, Mutator, Tools } from "final-form";
 
 // Same as https://github.com/final-form/final-form-set-field-data/blob/master/src/setFieldData.js
 // but with type definitions
-export const setFieldData: Mutator = <T, Data extends {}>(
+export const setFieldData: Mutator = <T, Data extends Record<string, any>>(
   args: [string, Data],
-  state: MutableState<T>,
-  tools: Tools<T>
+  state: MutableState<T>
+  //tools: Tools<T>
 ) => {
   const [name, data] = args;
   const field = state.fields[name];

--- a/src/validators/hasBalance.ts
+++ b/src/validators/hasBalance.ts
@@ -12,7 +12,9 @@ import { Validator } from "./types";
  */
 export const hasBalanceFactory = (
   getErc20Details: (address: string) => Promise<TokenBalance>
-) => (tokenAddress: string): Validator => (fieldName) => async (value) => {
+) => (tokenAddress: string): Validator => (/* fieldName */) => async (
+  value
+) => {
   // Don't validate unless we have all the required input
   if (!tokenAddress || !value) {
     return undefined;

--- a/src/validators/misc.ts
+++ b/src/validators/misc.ts
@@ -6,7 +6,7 @@ export const composeValidators = (
   validators: Validator[]
 ) => async (
   value: string,
-  allValues?: object,
+  allValues?: Record<string, any>,
   meta?: FieldState<string>
 ): Promise<undefined | ValidationError> => {
   for (const validator of validators) {

--- a/src/validators/types.ts
+++ b/src/validators/types.ts
@@ -4,7 +4,7 @@ export type Validator = (
   displayFieldName: string
 ) => (
   value: string,
-  allValues?: object,
+  allValues?: Record<string, any>,
   meta?: FieldState<string>
 ) => Promise<undefined | ValidationError>;
 


### PR DESCRIPTION
# Description

Typescript files weren't previously linted by the pre-commit hook. This PR adds linting for ts files and fixed most problems that required manual work as well as all automatic fixes and all errors.

The remaining linting warnings are:
![image](https://user-images.githubusercontent.com/969493/95075504-8fe5b800-0710-11eb-9cb8-4d9f5bcdf6b8.png)

Here's some changes I had to make:
```
/Users/andremeyer/Documents/Projects/safe-app-gnosis-protocol/src/utils/finalForm.ts
  5:55  error    Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types
```

```
/Users/andremeyer/Documents/Projects/safe-app-gnosis-protocol/src/components/pages/deploy/DeployPage.stories.tsx
  93:39  error    Unexpected empty async arrow function  @typescript-eslint/no-empty-function
```

Those are the kind of changes I made immediately, the remaining ones I don't feel safe just changing. Please either fix them whenever or ignore them for now @alfetopito 

# To Test
- `npm run lint -- --fix` runs without error

# Background

New dependency `@typescript-eslint/parser`
