### PR TITLE
Adjust component names

### DIFF
--- a/src/components/basic/display/MarketPrice/index.tsx
+++ b/src/components/basic/display/MarketPrice/index.tsx
@@ -12,39 +12,44 @@ export interface Props {
   setError?: (msg?: string) => void;
 }
 
-function UMarketPrice(props: Props): JSX.Element {
-  const { baseTokenAddress, quoteTokenAddress, setError, onPriceClick } = props;
+export const MarketPrice = memo(
+  (props: Props): JSX.Element => {
+    const {
+      baseTokenAddress,
+      quoteTokenAddress,
+      setError,
+      onPriceClick,
+    } = props;
 
-  // TODO: handle error
-  const { tokenDetails: baseToken } = useTokenDetails(baseTokenAddress);
-  const { tokenDetails: quoteToken } = useTokenDetails(quoteTokenAddress);
+    // TODO: handle error
+    const { tokenDetails: baseToken } = useTokenDetails(baseTokenAddress);
+    const { tokenDetails: quoteToken } = useTokenDetails(quoteTokenAddress);
 
-  // TODO: propagate error up to parent when dealing with validation
-  const { price, isLoading, error } = useGetPrice({
-    baseToken: baseToken,
-    quoteToken: quoteToken,
-    source: "1inch",
-  });
+    // TODO: propagate error up to parent when dealing with validation
+    const { price, isLoading, error } = useGetPrice({
+      baseToken: baseToken,
+      quoteToken: quoteToken,
+      source: "1inch",
+    });
 
-  const onClick = useCallback(() => {
-    if (onPriceClick && price && !isLoading) {
-      onPriceClick(price.toString());
-    }
-  }, [price, isLoading, onPriceClick]);
+    const onClick = useCallback(() => {
+      if (onPriceClick && price && !isLoading) {
+        onPriceClick(price.toString());
+      }
+    }, [price, isLoading, onPriceClick]);
 
-  useEffect(() => {
-    setError && setError(error);
-  }, [error, setError]);
+    useEffect(() => {
+      setError && setError(error);
+    }, [error, setError]);
 
-  return (
-    <MarketPriceViewer
-      baseTokenAddress={baseTokenAddress}
-      quoteTokenAddress={quoteTokenAddress}
-      isPriceLoading={isLoading}
-      price={price ? price.toString() : ""}
-      onClick={onClick}
-    />
-  );
-}
-
-export const MarketPrice: typeof UMarketPrice = memo(UMarketPrice);
+    return (
+      <MarketPriceViewer
+        baseTokenAddress={baseTokenAddress}
+        quoteTokenAddress={quoteTokenAddress}
+        isPriceLoading={isLoading}
+        price={price ? price.toString() : ""}
+        onClick={onClick}
+      />
+    );
+  }
+);

--- a/src/components/basic/display/Message/index.tsx
+++ b/src/components/basic/display/Message/index.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useMemo } from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Icon, Text } from "@gnosis.pm/safe-react-components";
 
@@ -39,7 +38,7 @@ const Wrapper = styled.div<Props>`
   }
 `;
 
-const UMessage: React.FC<Props> = (props: Props) => {
+export const Message = memo(function Message(props: Props): JSX.Element {
   const { type, label, children } = props;
 
   const msgBody = useMemo((): React.ReactNode => {
@@ -71,6 +70,4 @@ const UMessage: React.FC<Props> = (props: Props) => {
       {msgBody}
     </Wrapper>
   );
-};
-
-export const Message: typeof UMessage = memo(UMessage);
+});

--- a/src/components/basic/display/SubtextAmount/index.tsx
+++ b/src/components/basic/display/SubtextAmount/index.tsx
@@ -31,7 +31,9 @@ export interface Props extends WrapperProps {
   amount: string | React.ReactElement;
 }
 
-function USubtextAmount(props: Props): JSX.Element {
+export const SubtextAmount = memo(function SubtextAmount(
+  props: Props
+): JSX.Element {
   const { subtext, amount, inline } = props;
 
   return (
@@ -44,6 +46,4 @@ function USubtextAmount(props: Props): JSX.Element {
       </Text>
     </Wrapper>
   );
-}
-
-export const SubtextAmount: typeof USubtextAmount = memo(USubtextAmount);
+});

--- a/src/components/basic/display/TokenDisplay/index.tsx
+++ b/src/components/basic/display/TokenDisplay/index.tsx
@@ -22,7 +22,9 @@ export interface Props {
  * - display shortened address with link to Etherscan when symbol/name not available
  * - add support for displaying token images
  */
-function UTokenDisplay(props: Props): JSX.Element {
+export const TokenDisplay = memo(function TokenDisplay(
+  props: Props
+): JSX.Element {
   const { token, size, color } = props;
 
   // TODO: handle error
@@ -39,6 +41,4 @@ function UTokenDisplay(props: Props): JSX.Element {
       -
     </Text>
   );
-}
-
-export const TokenDisplay: typeof UTokenDisplay = memo(UTokenDisplay);
+});

--- a/src/components/basic/inputs/FundingInput/Label.tsx
+++ b/src/components/basic/inputs/FundingInput/Label.tsx
@@ -17,7 +17,7 @@ interface Props {
   disabled?: boolean;
 }
 
-function ULabel(props: Props): JSX.Element {
+export const Label = memo(function Label(props: Props): JSX.Element {
   const { onClick, error, disabled } = props;
   return (
     <Wrapper {...props}>
@@ -40,6 +40,4 @@ function ULabel(props: Props): JSX.Element {
       </ButtonLink>
     </Wrapper>
   );
-}
-
-export const Label: typeof ULabel = memo(ULabel);
+});

--- a/src/components/basic/inputs/TokenSelector/index.tsx
+++ b/src/components/basic/inputs/TokenSelector/index.tsx
@@ -24,7 +24,9 @@ export interface Props {
  * Deals with hooks and state.
  * To be used externally in other components
  */
-function UTokenSelector(props: Props): JSX.Element {
+export const TokenSelector = memo(function TokenSelector(
+  props: Props
+): JSX.Element {
   const { selectedTokenAddress, setError, ...rest } = props;
 
   const tokenList = useTokenList();
@@ -59,6 +61,4 @@ function UTokenSelector(props: Props): JSX.Element {
       isBalanceLoading={isLoading}
     />
   );
-}
-
-export const TokenSelector: typeof UTokenSelector = memo(UTokenSelector);
+});

--- a/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
+++ b/src/components/pages/deploy/DeployStrategyButtonFragment.tsx
@@ -10,22 +10,22 @@ const StyledButton = styled(Button)`
   font-weight: bold;
 `;
 
-function UDeployStrategyButtonFragment(): JSX.Element {
-  const { invalid, pristine, submitting } = useFormState({
-    subscription: { invalid: true, pristine: true, submitting: true },
-  });
+export const DeployStrategyButtonFragment = memo(
+  function DeployStrategyButtonFragment(): JSX.Element {
+    const { invalid, pristine, submitting } = useFormState({
+      subscription: { invalid: true, pristine: true, submitting: true },
+    });
 
-  return (
-    <StyledButton
-      type="submit"
-      size="lg"
-      color="primary"
-      variant="contained"
-      disabled={invalid || pristine || submitting}
-    >
-      <span>Deploy Strategy</span>
-    </StyledButton>
-  );
-}
-
-export const DeployStrategyButtonFragment = memo(UDeployStrategyButtonFragment);
+    return (
+      <StyledButton
+        type="submit"
+        size="lg"
+        color="primary"
+        variant="contained"
+        disabled={invalid || pristine || submitting}
+      >
+        <span>Deploy Strategy</span>
+      </StyledButton>
+    );
+  }
+);

--- a/src/components/pages/deploy/ErrorMessagesFragment.tsx
+++ b/src/components/pages/deploy/ErrorMessagesFragment.tsx
@@ -11,36 +11,36 @@ const Wrapper = styled.div`
   }
 `;
 
-function UErrorMessageFragment(): JSX.Element {
-  const { errors = {}, touched = {}, submitErrors = {} } = useFormState({
-    subscription: { errors: true, touched: true, submitErrors: true },
-  });
+export const ErrorMessagesFragment = memo(
+  function ErrorMessageFragment(): JSX.Element {
+    const { errors = {}, touched = {}, submitErrors = {} } = useFormState({
+      subscription: { errors: true, touched: true, submitErrors: true },
+    });
 
-  if ((!errors || !Object.values(touched).some(Boolean)) && !submitErrors) {
-    return null;
+    if ((!errors || !Object.values(touched).some(Boolean)) && !submitErrors) {
+      return null;
+    }
+
+    const allErrors = { ...errors, ...submitErrors };
+
+    return (
+      <Wrapper>
+        {Object.keys(errors)
+          .filter(
+            (fieldName) =>
+              // Only show errors messages when we have one
+              // Sometimes a field is set with 'error === true' only to highlight the component
+              // to avoid multiple messages for the same error that affects multiple components
+              // Also, do not show error messages for fields not `touched`
+              typeof allErrors[fieldName] !== "boolean" && touched[fieldName]
+          )
+          // Add submitErrors last because if they are here they should be displayed
+          // and also since they do not correlate to a field, it won't be in the `touched` obj
+          .concat(Object.keys(submitErrors))
+          .map((fieldName, id) => (
+            <Message {...allErrors[fieldName]} type="error" key={id} />
+          ))}
+      </Wrapper>
+    );
   }
-
-  const allErrors = { ...errors, ...submitErrors };
-
-  return (
-    <Wrapper>
-      {Object.keys(errors)
-        .filter(
-          (fieldName) =>
-            // Only show errors messages when we have one
-            // Sometimes a field is set with 'error === true' only to highlight the component
-            // to avoid multiple messages for the same error that affects multiple components
-            // Also, do not show error messages for fields not `touched`
-            typeof allErrors[fieldName] !== "boolean" && touched[fieldName]
-        )
-        // Add submitErrors last because if they are here they should be displayed
-        // and also since they do not correlate to a field, it won't be in the `touched` obj
-        .concat(Object.keys(submitErrors))
-        .map((fieldName, id) => (
-          <Message {...allErrors[fieldName]} type="error" key={id} />
-        ))}
-    </Wrapper>
-  );
-}
-
-export const ErrorMessagesFragment = memo(UErrorMessageFragment);
+);

--- a/src/components/pages/deploy/FormBackdrop.tsx
+++ b/src/components/pages/deploy/FormBackdrop.tsx
@@ -5,7 +5,7 @@ import { useFormState } from "react-final-form";
 
 const StyledBackdrop = withStyles(() => ({ root: { zIndex: 999 } }))(Backdrop);
 
-function UFormBackdrop(): JSX.Element {
+export const FormBackdrop = memo(function FormBackdrop(): JSX.Element {
   const { submitting } = useFormState({ subscription: { submitting: true } });
 
   return (
@@ -13,6 +13,4 @@ function UFormBackdrop(): JSX.Element {
       <Loader size="lg" color="primaryLight" />
     </StyledBackdrop>
   );
-}
-
-export const FormBackdrop = memo(UFormBackdrop);
+});

--- a/src/components/pages/deploy/MarketPriceFragment.tsx
+++ b/src/components/pages/deploy/MarketPriceFragment.tsx
@@ -8,34 +8,34 @@ const Wrapper = styled.div`
   align-self: center;
 `;
 
-function UMarketPriceFragment(): JSX.Element {
-  const {
-    input: { value: baseTokenAddress },
-  } = useField<string>("baseTokenAddress");
-  const {
-    input: { value: quoteTokenAddress },
-  } = useField<string>("quoteTokenAddress");
+export const MarketPriceFragment = memo(
+  function MarketPriceFragment(): JSX.Element {
+    const {
+      input: { value: baseTokenAddress },
+    } = useField<string>("baseTokenAddress");
+    const {
+      input: { value: quoteTokenAddress },
+    } = useField<string>("quoteTokenAddress");
 
-  const {
-    mutators: { setFieldValue },
-  } = useForm();
+    const {
+      mutators: { setFieldValue },
+    } = useForm();
 
-  const onPriceClick = useCallback(
-    (price: string) => {
-      setFieldValue("startPrice", { value: price });
-    },
-    [setFieldValue]
-  );
+    const onPriceClick = useCallback(
+      (price: string) => {
+        setFieldValue("startPrice", { value: price });
+      },
+      [setFieldValue]
+    );
 
-  return (
-    <Wrapper>
-      <MarketPrice
-        baseTokenAddress={baseTokenAddress}
-        quoteTokenAddress={quoteTokenAddress}
-        onPriceClick={onPriceClick}
-      />
-    </Wrapper>
-  );
-}
-
-export const MarketPriceFragment = memo(UMarketPriceFragment);
+    return (
+      <Wrapper>
+        <MarketPrice
+          baseTokenAddress={baseTokenAddress}
+          quoteTokenAddress={quoteTokenAddress}
+          onPriceClick={onPriceClick}
+        />
+      </Wrapper>
+    );
+  }
+);

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -55,23 +55,7 @@ const InvisibleField = styled(Field)`
   display: none;
 `;
 
-const onMaxClickFactory = (
-  field: FormFields,
-  tokenBalance: TokenBalance | null,
-  setFieldValue: (field: FormFields, data: { value: string }) => void
-) => () => {
-  if (tokenBalance) {
-    const value = formatAmountFull({
-      amount: tokenBalance.balance,
-      precision: tokenBalance.decimals,
-      thousandSeparator: false,
-      isLocaleAware: false,
-    });
-    setFieldValue(field, { value });
-  }
-};
-
-function UPricesFragment(): JSX.Element {
+export const PricesFragment = memo(function PricesFragment(): JSX.Element {
   const totalInvestment = useRecoilValue(totalInvestmentAtom);
 
   const {
@@ -90,13 +74,28 @@ function UPricesFragment(): JSX.Element {
     quoteTokenAddress
   );
 
+  const onMaxClickFactory = useCallback(
+    (field: FormFields, tokenBalance: TokenBalance | null): void => {
+      if (tokenBalance) {
+        const value = formatAmountFull({
+          amount: tokenBalance.balance,
+          precision: tokenBalance.decimals,
+          thousandSeparator: false,
+          isLocaleAware: false,
+        });
+        setFieldValue(field, { value });
+      }
+    },
+    [setFieldValue]
+  );
+
   const onBaseTokenMaxClick = useCallback(
-    onMaxClickFactory("baseTokenAmount", baseTokenDetails, setFieldValue),
-    [baseTokenDetails, setFieldValue]
+    () => onMaxClickFactory("baseTokenAmount", baseTokenDetails),
+    [baseTokenDetails, onMaxClickFactory]
   );
   const onQuoteTokenMaxClick = useCallback(
-    onMaxClickFactory("quoteTokenAmount", quoteTokenDetails, setFieldValue),
-    [quoteTokenDetails, setFieldValue]
+    () => onMaxClickFactory("quoteTokenAmount", quoteTokenDetails),
+    [onMaxClickFactory, quoteTokenDetails]
   );
 
   return (
@@ -223,6 +222,4 @@ function UPricesFragment(): JSX.Element {
       <InvisibleField name="calculatedBrackets" component="input" />
     </Wrapper>
   );
-}
-
-export const PricesFragment = memo(UPricesFragment);
+});

--- a/src/components/pages/deploy/SideBar.tsx
+++ b/src/components/pages/deploy/SideBar.tsx
@@ -102,7 +102,7 @@ const StyledAccordionDetails = withStyles({
   },
 })(AccordionDetails);
 
-function USideBar(): JSX.Element {
+export const SideBar = memo(function SideBar(): JSX.Element {
   return (
     <Wrapper>
       <div>
@@ -142,6 +142,4 @@ function USideBar(): JSX.Element {
       </StyledAccordion>
     </Wrapper>
   );
-}
-
-export const SideBar = memo(USideBar);
+});

--- a/src/components/pages/deploy/TokenSelectorsFragment.tsx
+++ b/src/components/pages/deploy/TokenSelectorsFragment.tsx
@@ -19,42 +19,42 @@ const Wrapper = styled.div`
   }
 `;
 
-function UTokenSelectorsFragment(): JSX.Element {
-  const {
-    mutators: { swapTokens },
-  } = useForm();
+export const TokenSelectorsFragment = memo(
+  function TokenSelectorsFragment(): JSX.Element {
+    const {
+      mutators: { swapTokens },
+    } = useForm();
 
-  return (
-    <Wrapper>
-      <Field<string>
-        name="baseTokenAddress"
-        validate={isRequired()("Token A")}
-        render={({ input }) => (
-          <TokenSelector
-            label="Pick Token A"
-            tooltip="This is the token that will be used to buy token B"
-            onSelect={input.onChange}
-            selectedTokenAddress={input.value}
-          />
-        )}
-      />
-      <Link onClick={swapTokens} textSize="sm" color="text">
-        <Icon type="transactionsInactive" size="md" className="swapIcon" />
-      </Link>
-      <Field<string>
-        name="quoteTokenAddress"
-        validate={isRequired()("Token B")}
-        render={({ input }) => (
-          <TokenSelector
-            label="Pick Token B"
-            tooltip="This is the token that will be sold for token A"
-            onSelect={input.onChange}
-            selectedTokenAddress={input.value}
-          />
-        )}
-      />
-    </Wrapper>
-  );
-}
-
-export const TokenSelectorsFragment = memo(UTokenSelectorsFragment);
+    return (
+      <Wrapper>
+        <Field<string>
+          name="baseTokenAddress"
+          validate={isRequired()("Token A")}
+          render={({ input }) => (
+            <TokenSelector
+              label="Pick Token A"
+              tooltip="This is the token that will be used to buy token B"
+              onSelect={input.onChange}
+              selectedTokenAddress={input.value}
+            />
+          )}
+        />
+        <Link onClick={swapTokens} textSize="sm" color="text">
+          <Icon type="transactionsInactive" size="md" className="swapIcon" />
+        </Link>
+        <Field<string>
+          name="quoteTokenAddress"
+          validate={isRequired()("Token B")}
+          render={({ input }) => (
+            <TokenSelector
+              label="Pick Token B"
+              tooltip="This is the token that will be sold for token A"
+              onSelect={input.onChange}
+              selectedTokenAddress={input.value}
+            />
+          )}
+        />
+      </Wrapper>
+    );
+  }
+);

--- a/src/components/pages/deploy/viewer.tsx
+++ b/src/components/pages/deploy/viewer.tsx
@@ -40,7 +40,7 @@ const DeployWidget = styled.div`
   align-items: stretch;
 `;
 
-function UDeployPageViewer(): JSX.Element {
+export const DeployPageViewer = memo(function DeployPageViewer(): JSX.Element {
   return (
     <PageLayout>
       <DeployForm>
@@ -56,6 +56,4 @@ function UDeployPageViewer(): JSX.Element {
       <SideBar />
     </PageLayout>
   );
-}
-
-export const DeployPageViewer = memo(UDeployPageViewer);
+});


### PR DESCRIPTION
# Description

Follow up to https://github.com/gnosis/safe-cmm-app-react/pull/82

- Exporting `memo` components directly
- Removing `propTypes` in favor or a `Props` interface
- Moved some functions inside component to handle issue with callbacks

# To Test
- [ ] Try out the validation

# Background

Even though the components are exported, the inner functions are still named. Example:

```
export const Message = memo(function Message(props: Props): JSX.Element 
```

That's because `memo` requires a react component.
If passing in an anonymous function, we'll need to provide a `name` attribute (_Component definition is missing display name_).
So I named the inner function with the same name as the exported component.
No conflicts there as the function exists only within that scope.

