### PR TITLE
Allow start price outside range

### DIFF
--- a/src/components/pages/deploy/DeployForm.tsx
+++ b/src/components/pages/deploy/DeployForm.tsx
@@ -153,9 +153,7 @@ export const DeployForm = memo(function DeployForm({
 
       // prices values
       const lowestPrice = Number(values.lowestPrice);
-      const startPrice = Number(values.startPrice);
       const highestPrice = Number(values.highestPrice);
-      // const totalBrackets = Number(values.totalBrackets);
 
       // this is a calculated field where we store two integers in a single string
       const baseTokenBrackets = getBracketValue(
@@ -167,21 +165,10 @@ export const DeployForm = memo(function DeployForm({
         "quote"
       );
 
-      if (lowestPrice > startPrice) {
+      if (lowestPrice >= highestPrice) {
         errors["lowestPrice"] = {
-          label: "Lowest price can't be greater than Start price",
+          label: "Lowest Price must be smaller than Highest Price",
         };
-        errors["startPrice"] = true;
-      }
-      if (highestPrice < startPrice) {
-        errors["highestPrice"] = {
-          label: "Highest price can't be smaller than Start price",
-        };
-        errors["startPrice"] = true;
-      }
-      if (lowestPrice === startPrice && startPrice === highestPrice) {
-        errors["startPrice"] = { label: "All prices cannot be equal" };
-        errors["lowestPrice"] = true;
         errors["highestPrice"] = true;
       }
 

--- a/src/components/pages/deploy/DeployForm.tsx
+++ b/src/components/pages/deploy/DeployForm.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useCallback, useContext } from "react";
-import PropTypes from "prop-types";
 import {
   FormApi,
   FormState,
@@ -212,11 +211,6 @@ export const DeployForm = memo(function DeployForm({
     },
     [hasBalance]
   );
-
-  // const validate = useCallback(
-  //   validateFactory(hasBalanceFactory(getErc20Details)),
-  //   [getErc20Details]
-  // );
 
   // The initial idea was to keep all the logic only on the container (index) component
   // But with the validations and final-form I didn't manage to.

--- a/src/utils/calculateBrackets.ts
+++ b/src/utils/calculateBrackets.ts
@@ -40,8 +40,8 @@ export function calculateBrackets(params: Params): Result {
     isNaN(highestPriceNum) ||
     isNaN(totalBrackets) ||
     lowestPriceNum <= 0 ||
-    lowestPriceNum > startPriceNum ||
-    startPriceNum > highestPriceNum ||
+    startPriceNum <= 0 ||
+    lowestPriceNum >= highestPriceNum ||
     totalBrackets <= 0
   ) {
     return { baseTokenBrackets: 0, quoteTokenBrackets: 0 };

--- a/test/utils/calculateBrackets.test.ts
+++ b/test/utils/calculateBrackets.test.ts
@@ -7,6 +7,7 @@ const baseParams: Params = {
   highestPrice: "1.2",
   totalBrackets: "3",
 };
+
 test("totalBrackets == 0", () => {
   const params = clone(baseParams);
   params.totalBrackets = "0";
@@ -16,6 +17,7 @@ test("totalBrackets == 0", () => {
     quoteTokenBrackets: 0,
   });
 });
+
 test("totalBrackets == 1", () => {
   const params = clone(baseParams);
   params.totalBrackets = "1";
@@ -25,6 +27,7 @@ test("totalBrackets == 1", () => {
     quoteTokenBrackets: 1,
   });
 });
+
 test("even brackets", () => {
   const params = clone(baseParams);
   params.totalBrackets = "2";
@@ -34,6 +37,7 @@ test("even brackets", () => {
     quoteTokenBrackets: 1,
   });
 });
+
 test("odd brackets", () => {
   const params = clone(baseParams);
 
@@ -42,6 +46,17 @@ test("odd brackets", () => {
     quoteTokenBrackets: 2,
   });
 });
+
+test("lowestPrice > startPrice", () => {
+  const params = clone(baseParams);
+  params.startPrice = (Number(params.lowestPrice) * 0.9).toString();
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 3,
+    quoteTokenBrackets: 0,
+  });
+});
+
 test("lowestPrice == startPrice", () => {
   const params = clone(baseParams);
   params.startPrice = params.lowestPrice;
@@ -51,6 +66,7 @@ test("lowestPrice == startPrice", () => {
     quoteTokenBrackets: 0,
   });
 });
+
 test("startPrice == highestPrice", () => {
   const params = clone(baseParams);
   params.startPrice = params.highestPrice;
@@ -60,6 +76,17 @@ test("startPrice == highestPrice", () => {
     quoteTokenBrackets: 3,
   });
 });
+
+test("startPrice > highestPrice", () => {
+  const params = clone(baseParams);
+  params.startPrice = (Number(params.highestPrice) * 1.1).toString();
+
+  expect(calculateBrackets(params)).toEqual({
+    baseTokenBrackets: 0,
+    quoteTokenBrackets: 3,
+  });
+});
+
 test("startPrice == bracket boundary", () => {
   const params = clone(baseParams);
   // value manually calculated:
@@ -108,15 +135,15 @@ describe("invalid params", () => {
     expect(calculateBrackets(params)).toEqual(invalidResponse);
   });
 
-  test("lowestPrice > startPrice", () => {
+  test("startPrice < 0", () => {
     const params = clone(baseParams);
-    params.lowestPrice = "1" + params.startPrice;
+    params.startPrice = "-1";
     expect(calculateBrackets(params)).toEqual(invalidResponse);
   });
 
-  test("startPrice > highestPrice", () => {
+  test("lowestPrice > highestPrice", () => {
     const params = clone(baseParams);
-    params.startPrice = "1" + params.highestPrice;
+    params.lowestPrice = params.highestPrice;
     expect(calculateBrackets(params)).toEqual(invalidResponse);
   });
 


### PR DESCRIPTION
# Description

Adjusted error validation to allow `start price` to be outside of `lowest price` - `highest price` range.
![screenshot_2020-10-05_15-54-31](https://user-images.githubusercontent.com/43217/95140152-08557480-0723-11eb-9327-fa65aaae3a8f.png)

The rules now on prices are:
- all are required
- all are numbers
- all are > 0
- `lowest price` > `highest price`


# To Test
- [ ] Test validation with `start price` outside of `lowest price` - `highest price` range

# Background

Depends on #84.
To be merged after that one.

