### PR TITLE
Added missing tooltips for MarketPrice and TotalBrackets

### DIFF
--- a/src/components/basic/display/MarketPrice/viewer.tsx
+++ b/src/components/basic/display/MarketPrice/viewer.tsx
@@ -48,7 +48,7 @@ function UMarketPriceViewer(props: MarketPriceViewerProps): JSX.Element {
             per
           </Text>
           <TokenDisplay token={baseTokenAddress} size="md" />
-          <Tooltip title="TODO: add tooltip!!">
+          <Tooltip title="Reflects the current market price of Token B, denominated in Token A.">
             <Icon type="question" size="sm" />
           </Tooltip>
         </Amount>

--- a/src/components/basic/inputs/TotalBrackets/index.tsx
+++ b/src/components/basic/inputs/TotalBrackets/index.tsx
@@ -31,7 +31,10 @@ export const TotalBrackets = (props: Props): JSX.Element => {
         inputWidth="75px"
         center
         customLabel={
-          <TextWithTooltip tooltip="TODO: add tooltips :)" size="lg">
+          <TextWithTooltip
+            tooltip="Each bracket consists of a single Ethereum address that places a buy-low and a sell-high order. Every time the price goes through a bracket and activates both orders, the CMM provider earns the spread."
+            size="lg"
+          >
             Total Brackets
           </TextWithTooltip>
         }


### PR DESCRIPTION
# Description

Added missing tooltips for MarketPrice and TotalBrackets

Closes #37 

# To Test
- [ ] On deployment page, verify all `?` have a tooltip associated with it, and it matches what's defined on the design doc
![screenshot_2020-10-06_10-21-34](https://user-images.githubusercontent.com/43217/95238035-ce857c00-07bd-11eb-817e-aa91f74397c3.png)


# Background

n/a

