### PR TITLE
Added links to support side bar

### DIFF
--- a/src/components/pages/deploy/SideBar.tsx
+++ b/src/components/pages/deploy/SideBar.tsx
@@ -112,14 +112,18 @@ export const SideBar = memo(function SideBar(): JSX.Element {
 
         <Text size="lg" as="span">
           👉 Check out the{" "}
-          <Link textSize="lg" color="primary" href="#add-link-here">
+          <Link
+            textSize="lg"
+            color="primary"
+            href="https://docs.gnosis.io/protocol/docs/intro-cmm/"
+          >
             GP CMM intro article
           </Link>
         </Text>
 
         <Text size="lg">
           👉{" "}
-          <Link textSize="lg" color="primary" href="#add-link-here">
+          <Link textSize="lg" color="primary" href="https://chat.gnosis.io/ ">
             Join Discord
           </Link>
         </Text>


### PR DESCRIPTION
# Description

Added links to support side bar

# To Test
- [ ] On deploy page, verify links lead to where they are supposed to. Respectively:
  - [ ] GP CMM intro article -> https://docs.gnosis.io/protocol/docs/intro-cmm/
  - [ ] Join Discord -> https://chat.gnosis.io/
![screenshot_2020-10-06_10-28-48](https://user-images.githubusercontent.com/43217/95238711-c0842b00-07be-11eb-83af-d0b4848c1696.png)
  
# Background

n/a

