### PR TITLE
Total investment calculation

### DIFF
--- a/src/components/basic/display/SubtextAmount/index.tsx
+++ b/src/components/basic/display/SubtextAmount/index.tsx
@@ -28,7 +28,7 @@ const Wrapper = styled.div<WrapperProps>`
 
 export interface Props extends WrapperProps {
   subtext: string;
-  amount: string | React.ReactElement;
+  amount: React.ReactNode;
 }
 
 export const SubtextAmount = memo(function SubtextAmount(

--- a/src/components/pages/deploy/DeployForm.tsx
+++ b/src/components/pages/deploy/DeployForm.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useCallback, useContext } from "react";
-import PropTypes from "prop-types";
 import {
   FormApi,
   FormState,

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useCallback } from "react";
-import { useRecoilValue } from "recoil";
 import { Field, useField, useForm } from "react-final-form";
 import styled from "styled-components";
 
@@ -8,6 +7,8 @@ import { formatAmountFull } from "@gnosis.pm/dex-js";
 import { useTokenDetails } from "hooks/useTokenDetails";
 
 import { TokenBalance } from "types";
+
+import { MAXIMUM_BRACKETS, MINIMUM_BRACKETS } from "utils/constants";
 
 import { PriceInput } from "components/basic/inputs/PriceInput";
 import { FundingInput } from "components/basic/inputs/FundingInput";
@@ -18,9 +19,6 @@ import { isRequired } from "validators/isRequired";
 import { isNumber } from "validators/isNumber";
 import { isGreaterThan } from "validators/isGreaterThan";
 import { isSmallerThan } from "validators/isSmallerThan";
-import { MAXIMUM_BRACKETS, MINIMUM_BRACKETS } from "utils/constants";
-
-import { totalInvestmentAtom } from "./atoms";
 
 import { getBracketValue } from "./DeployForm";
 import { FormFields } from "./types";
@@ -56,14 +54,18 @@ const InvisibleField = styled(Field)`
 `;
 
 export const PricesFragment = memo(function PricesFragment(): JSX.Element {
-  const totalInvestment = useRecoilValue(totalInvestmentAtom);
-
   const {
     input: { value: baseTokenAddress },
   } = useField<string>("baseTokenAddress");
   const {
     input: { value: quoteTokenAddress },
   } = useField<string>("quoteTokenAddress");
+  const {
+    input: { value: baseTokenAmount },
+  } = useField<string>("baseTokenAmount");
+  const {
+    input: { value: quoteTokenAmount },
+  } = useField<string>("quoteTokenAmount");
 
   const {
     mutators: { setFieldValue },
@@ -173,7 +175,10 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
               {...input}
               warn={meta.touched && !!meta.data?.warn}
               error={meta.touched && meta.error}
-              amount={totalInvestment}
+              baseTokenAddress={baseTokenAddress}
+              baseTokenAmount={baseTokenAmount}
+              quoteTokenAddress={quoteTokenAddress}
+              quoteTokenAmount={quoteTokenAmount}
             />
           )}
         />

--- a/src/hooks/useAmountInUsd.ts
+++ b/src/hooks/useAmountInUsd.ts
@@ -1,0 +1,50 @@
+import Decimal from "decimal.js";
+import { useGetPrice } from "./useGetPrice";
+import { useTokenDetails } from "./useTokenDetails";
+
+// Quote price in USDC
+const USDC = {
+  address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  decimals: 6,
+  symbol: "USDC",
+  name: "USDC",
+};
+
+type Params = {
+  tokenAddress?: string;
+  amount?: string;
+};
+
+type Result = {
+  isLoading: boolean;
+  amountInUsd: Decimal | null;
+  error: string;
+};
+
+/**
+ * Quotes given amount of token in USDC
+ */
+export function useAmountInUsd(params: Params): Result {
+  const { tokenAddress, amount } = params;
+
+  // Setting address to be queried `undefined` when no amount is provided
+  // to avoid fetching price when there's no amount
+  const address = Number(amount) > 0 ? tokenAddress : undefined;
+
+  const {
+    tokenDetails: baseToken,
+    isLoading: isLoadingTokenDetails,
+    error: tokenDetailsError,
+  } = useTokenDetails(address);
+
+  const { price, isLoading: isLoadingPrice, error: priceError } = useGetPrice({
+    baseToken,
+    quoteToken: USDC,
+  });
+
+  return {
+    isLoading: isLoadingTokenDetails || isLoadingPrice,
+    amountInUsd: price?.mul(new Decimal(amount)),
+    error: tokenDetailsError || priceError || "",
+  };
+}

--- a/src/hooks/useAmountInUsd.ts
+++ b/src/hooks/useAmountInUsd.ts
@@ -44,7 +44,7 @@ export function useAmountInUsd(params: Params): Result {
 
   return {
     isLoading: isLoadingTokenDetails || isLoadingPrice,
-    amountInUsd: price?.mul(new Decimal(amount)),
+    amountInUsd: address && price ? price.mul(amount) : null,
     error: tokenDetailsError || priceError || "",
   };
 }

--- a/src/hooks/useGetPrice.ts
+++ b/src/hooks/useGetPrice.ts
@@ -5,7 +5,7 @@ import NodeCache from "node-cache";
 import { getOneinchPrice } from "@gnosis.pm/dex-liquidity-provision/scripts/utils/price_utils";
 
 import { TokenDetails } from "types";
-import { ONE_DECIMAL, PRICE_CACHE_TIME } from "utils/constants";
+import { PRICE_CACHE_TIME } from "utils/constants";
 
 export type PriceSources = "1inch";
 

--- a/src/mock/useAmountInUsd.ts
+++ b/src/mock/useAmountInUsd.ts
@@ -1,0 +1,27 @@
+import { useAmountInUsd as hook } from "hooks/useAmountInUsd";
+import { createMockHook } from "./mockHookContext";
+
+/**
+ * Mock version of `useAmountInUsd` hook
+ *
+ * Customizable via story parameters, such as:
+ *
+ * MyStory.parameters = {
+ *  useAmountInUsd: {
+ *    amountInUsd: new Decimal('13'),
+ *    isLoading: true,
+ *    error: 'Something went wrong'
+ *  }
+ * or
+ *  useAmountInUsd: (...argsPassedToHook) => ({
+ *    amountInUsd: new Decimal('13'),
+ *    isLoading: true,
+ *    error: 'Something went wrong'
+ *  })
+ * }
+ */
+export const useAmountInUsd = createMockHook<typeof hook>("useAmountInUsd", {
+  amountInUsd: null,
+  isLoading: false,
+  error: "",
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,6 +23,7 @@ export const SAFE_ENDPOINT_URL =
 
 export const DEFAULT_INPUT_WIDTH = "130px";
 
+export const ZERO_DECIMAL = new Decimal("0");
 export const ONE_DECIMAL = new Decimal("1");
 
 export const MINIMUM_BRACKETS = 1;


### PR DESCRIPTION
# Description

Total investment calculation

# To Test
On deploy page:
1. Pick any two tokens
2. Fill in all prices fields
3. Fill in total brackets

- [ ] Throughout the process `Total investment` should display a `-`
![screenshot_2020-10-06_15-25-21](https://user-images.githubusercontent.com/43217/95266496-1f11cf00-07e8-11eb-97e7-9c89cf35ba55.png)

4. Fill in a value on one of the funding inputs.
- [ ] Total investment should show an amount equivalent to inserted amount * price of given token against USDC on 1inch
- [ ] There might be a loading indicator
![screenshot_2020-10-06_15-27-35](https://user-images.githubusercontent.com/43217/95266635-6ef09600-07e8-11eb-976b-d4fec5a0ba6b.png)

5. Fill in a value on the other funding input.
- [ ] Total investment should show a sum of both funding amounts * price of respective tokens against USDC on 1inch
- [ ] There might be a loading indicator
![screenshot_2020-10-06_15-29-06](https://user-images.githubusercontent.com/43217/95266734-a65f4280-07e8-11eb-8f9d-62cf86c17c5f.png)

5. Remove one or both funding input values
- [ ] `Total investment` should deduct the corresponding amount, and when no funding value is present, return it back to a `-`

# Background

n/a

