### PR TITLE
Feature/#94/brackets visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6303,6 +6303,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -6532,6 +6533,7 @@
       "version": "0.63.17",
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.17.tgz",
       "integrity": "sha512-xSU9JCHKGqC5Mxnqoc5xs4dquo2bW3ttNqz7IWRtHqEKQvbDcXUgZPNNqEKBiq+5ifMcJs5Dex7jgu8ywKoXBA==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -6586,6 +6588,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.3.tgz",
       "integrity": "sha512-HGpirof3WOhiX17lb61Q/tpgqn48jxO8EfZkdJ8ueYqwLbK2AHQe/G08DasdA2IdKnmwOIP1s9X2bopxKXgjRw==",
+      "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -6596,7 +6599,8 @@
         "csstype": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+          "dev": true
         }
       }
     },

--- a/src/components/basic/display/BracketsView/Bar.tsx
+++ b/src/components/basic/display/BracketsView/Bar.tsx
@@ -1,0 +1,20 @@
+import React, { memo } from "react";
+import styled from "styled-components";
+
+import { Needle } from "./Needle";
+import { Brackets } from "./Brackets";
+
+const Wrapper = styled.div`
+  width: inherit;
+  height: 46px;
+  position: relative;
+`;
+
+export const Bar = memo(function Bar(): JSX.Element {
+  return (
+    <Wrapper>
+      <Needle />
+      <Brackets />
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/Brackets.tsx
+++ b/src/components/basic/display/BracketsView/Brackets.tsx
@@ -1,0 +1,74 @@
+import React, { memo, useContext } from "react";
+import styled from "styled-components";
+import { range } from "lodash";
+
+import { BracketsViewContext } from "./viewer";
+
+// TODO: move to const? theme?
+const LEFT_BACKGROUND_COLOR = "rgba(0, 156, 180, 0.1)";
+const RIGHT_BACKGROUND_COLOR = "rgba(128, 94, 255, 0.1)";
+const LEFT_BORDER_LIGHT = "2px solid rgba(0, 156, 180, 0.2)";
+const LEFT_BORDER_THICK = "2px solid #009cb4";
+const RIGHT_BORDER_LIGHT = "2px solid rgba(128, 94, 255, 0.2)";
+const RIGHT_BORDER_THICK = "2px solid #805eff";
+
+const Wrapper = styled.div<{ hasLeftBrackets?: boolean }>`
+  height: inherit;
+  display: flex;
+
+  & > * {
+    width: 100%;
+  }
+
+  /* Default to left side color */
+  background-color: ${LEFT_BACKGROUND_COLOR};
+
+  .left:first-of-type {
+    border-left: ${LEFT_BORDER_THICK};
+  }
+
+  .left {
+    border-right: ${LEFT_BORDER_LIGHT};
+  }
+
+  .left:last-of-type {
+    border-right: ${LEFT_BORDER_THICK};
+  }
+
+  ${({ hasLeftBrackets }) =>
+    hasLeftBrackets
+      ? ""
+      : `
+  .right:first-of-type {
+    border-left: ${RIGHT_BORDER_THICK};
+  }`}
+
+  .right {
+    background-color: ${RIGHT_BACKGROUND_COLOR};
+
+    border-right: ${RIGHT_BORDER_LIGHT};
+  }
+
+  .right:last-of-type {
+    border-right: ${RIGHT_BORDER_THICK};
+  }
+`;
+
+export const Brackets = memo(function Brackets(): JSX.Element {
+  const { totalBrackets, leftBrackets, rightBrackets } = useContext(
+    BracketsViewContext
+  );
+
+  return (
+    <Wrapper hasLeftBrackets={!!leftBrackets}>
+      {range(
+        !leftBrackets && !rightBrackets ? totalBrackets : leftBrackets
+      ).map((id) => (
+        <div className="left" key={id} />
+      ))}
+      {range(rightBrackets).map((id) => (
+        <div className="right" key={id + leftBrackets} />
+      ))}
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/BracketsView.stories.tsx
+++ b/src/components/basic/display/BracketsView/BracketsView.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react/types-6-0";
+
+import { BracketsViewView, Props } from "./viewer";
+
+export default {
+  component: BracketsViewView,
+  title: "basic/display/BracketsView",
+  decorators: [(Story) => <div style={{ width: "400px" }}>{Story()}</div>],
+} as Meta;
+
+const minimumData: Props = { type: "deploy" };
+
+const Template: Story<Props> = (props) => <BracketsViewView {...props} />;
+
+export const DeployDefault = Template.bind({});
+DeployDefault.args = {
+  ...minimumData,
+  totalBrackets: 5,
+  leftBrackets: 3,
+  rightBrackets: 2,
+
+  baseTokenAddress: "0x",
+  quoteTokenAddress: "0x",
+
+  lowestPrice: "0",
+  highestPrice: "0",
+};
+
+export const DeployMinimal = Template.bind({});
+DeployMinimal.args = { ...minimumData };
+
+export const DeployAllLeft = Template.bind({});
+DeployAllLeft.args = {
+  ...DeployDefault.args,
+  totalBrackets: 3,
+  leftBrackets: 3,
+  rightBrackets: 0,
+};
+
+export const DeployAllRight = Template.bind({});
+DeployAllRight.args = {
+  ...DeployDefault.args,
+  totalBrackets: 3,
+  leftBrackets: 0,
+  rightBrackets: 3,
+};

--- a/src/components/basic/display/BracketsView/BracketsView.stories.tsx
+++ b/src/components/basic/display/BracketsView/BracketsView.stories.tsx
@@ -89,6 +89,26 @@ DeployStartPriceSmallerThanLowestPrice.args = {
   rightBrackets: 5,
 };
 
+export const DeployStartPriceEqualToLowestPrice = Template.bind({});
+DeployStartPriceEqualToLowestPrice.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "1",
+  leftBrackets: 0,
+  rightBrackets: 5,
+};
+
+export const DeployStartPriceEqualToHighestPrice = Template.bind({});
+DeployStartPriceEqualToHighestPrice.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "5",
+  leftBrackets: 5,
+  rightBrackets: 0,
+};
+
 export const DeployStartPriceGreaterThanHighestPrice = Template.bind({});
 DeployStartPriceGreaterThanHighestPrice.args = {
   ...DeployDefault.args,

--- a/src/components/basic/display/BracketsView/BracketsView.stories.tsx
+++ b/src/components/basic/display/BracketsView/BracketsView.stories.tsx
@@ -9,13 +9,13 @@ export default {
   decorators: [(Story) => <div style={{ width: "400px" }}>{Story()}</div>],
 } as Meta;
 
-const minimumData: Props = { type: "deploy" };
+const requiredData: Props = { type: "deploy" };
 
 const Template: Story<Props> = (props) => <BracketsViewView {...props} />;
 
 export const DeployDefault = Template.bind({});
 DeployDefault.args = {
-  ...minimumData,
+  ...requiredData,
   totalBrackets: 5,
   leftBrackets: 3,
   rightBrackets: 2,
@@ -25,23 +25,76 @@ DeployDefault.args = {
 
   lowestPrice: "0",
   highestPrice: "0",
+  startPrice: "5.8",
 };
 
 export const DeployMinimal = Template.bind({});
-DeployMinimal.args = { ...minimumData };
+DeployMinimal.args = { ...requiredData };
 
-export const DeployAllLeft = Template.bind({});
-DeployAllLeft.args = {
+export const DeployAllBracketsLeft = Template.bind({});
+DeployAllBracketsLeft.args = {
   ...DeployDefault.args,
   totalBrackets: 3,
   leftBrackets: 3,
   rightBrackets: 0,
 };
 
-export const DeployAllRight = Template.bind({});
-DeployAllRight.args = {
+export const DeployAllBracketsRight = Template.bind({});
+DeployAllBracketsRight.args = {
   ...DeployDefault.args,
   totalBrackets: 3,
   leftBrackets: 0,
   rightBrackets: 3,
+};
+
+export const DeployStartPriceCloseToLowestPrice = Template.bind({});
+DeployStartPriceCloseToLowestPrice.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "1.1",
+};
+
+export const DeployStartPriceAt25Percent = Template.bind({});
+DeployStartPriceAt25Percent.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "2",
+};
+
+export const DeployStartPriceAt75Percent = Template.bind({});
+DeployStartPriceAt75Percent.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "4",
+};
+
+export const DeployStartPriceCloseToHighestPrice = Template.bind({});
+DeployStartPriceCloseToHighestPrice.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "4.9",
+};
+
+export const DeployStartPriceSmallerThanLowestPrice = Template.bind({});
+DeployStartPriceSmallerThanLowestPrice.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "0.1",
+  leftBrackets: 0,
+  rightBrackets: 5,
+};
+
+export const DeployStartPriceGreaterThanHighestPrice = Template.bind({});
+DeployStartPriceGreaterThanHighestPrice.args = {
+  ...DeployDefault.args,
+  lowestPrice: "1",
+  highestPrice: "5",
+  startPrice: "5.5",
+  leftBrackets: 5,
+  rightBrackets: 0,
 };

--- a/src/components/basic/display/BracketsView/Footer.tsx
+++ b/src/components/basic/display/BracketsView/Footer.tsx
@@ -1,0 +1,133 @@
+import React, { memo, useCallback, useContext, useMemo } from "react";
+import styled from "styled-components";
+
+import { BracketsViewContext } from "./viewer";
+import { PriceDisplay } from "./PriceDisplay";
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 14px;
+  margin-top: 0.4em;
+
+  & > * {
+    width: 100%;
+  }
+
+  .justifyRight {
+    justify-content: right;
+  }
+`;
+
+const TwoPrices = styled.span`
+  display: flex;
+
+  & > :first-child {
+    margin-right: 0.5em;
+  }
+`;
+
+export const Footer = memo(function Footer(): JSX.Element {
+  const {
+    baseTokenAddress,
+    startPrice,
+    lowestPrice,
+    highestPrice,
+    needlePosition,
+    lowerThreshold,
+    upperThreshold,
+  } = useContext(BracketsViewContext);
+
+  const startPriceDisplayFactory = useCallback(
+    (
+      adornment?: "left" | "right",
+      isOutOfRange?: boolean,
+      className?: string
+    ) => {
+      return (
+        startPrice && (
+          <PriceDisplay
+            price={startPrice}
+            token={baseTokenAddress}
+            adornment={adornment}
+            color="primary"
+            isOutOfRange={isOutOfRange}
+            className={className}
+          />
+        )
+      );
+    },
+    [baseTokenAddress, startPrice]
+  );
+
+  const lowestPriceDisplay = useMemo(() => {
+    return (
+      lowestPrice && (
+        <PriceDisplay price={lowestPrice} token={baseTokenAddress} />
+      )
+    );
+  }, [baseTokenAddress, lowestPrice]);
+
+  const highestPriceDisplay = useMemo(() => {
+    return (
+      highestPrice && (
+        <PriceDisplay
+          price={highestPrice}
+          token={baseTokenAddress}
+          className="justifyRight"
+        />
+      )
+    );
+  }, [baseTokenAddress, highestPrice]);
+
+  const leftSide = useMemo(() => {
+    if (needlePosition < 0) {
+      return startPriceDisplayFactory("left", true);
+    } else if (needlePosition === 0) {
+      return startPriceDisplayFactory();
+    } else if (needlePosition < lowerThreshold) {
+      return (
+        <TwoPrices>
+          {lowestPriceDisplay}
+          {startPriceDisplayFactory()}
+        </TwoPrices>
+      );
+    } else {
+      return lowestPriceDisplay;
+    }
+  }, [
+    lowerThreshold,
+    lowestPriceDisplay,
+    needlePosition,
+    startPriceDisplayFactory,
+  ]);
+
+  const rightSide = useMemo(() => {
+    if (needlePosition > 100) {
+      return startPriceDisplayFactory("right", true, "justifyRight");
+    } else if (needlePosition === 100) {
+      return startPriceDisplayFactory(undefined, false, "justifyRight");
+    } else if (needlePosition >= upperThreshold) {
+      return (
+        <TwoPrices className="justifyRight">
+          {startPriceDisplayFactory(undefined, false, "justifyRight")}
+          {highestPriceDisplay}
+        </TwoPrices>
+      );
+    } else {
+      return highestPriceDisplay;
+    }
+  }, [
+    highestPriceDisplay,
+    needlePosition,
+    startPriceDisplayFactory,
+    upperThreshold,
+  ]);
+
+  return (
+    <Wrapper>
+      {leftSide}
+      {rightSide}
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/Footer.tsx
+++ b/src/components/basic/display/BracketsView/Footer.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
   }
 
   .justifyRight {
-    justify-content: right;
+    justify-content: flex-end;
   }
 `;
 

--- a/src/components/basic/display/BracketsView/Footer.tsx
+++ b/src/components/basic/display/BracketsView/Footer.tsx
@@ -51,6 +51,7 @@ export const Footer = memo(function Footer(): JSX.Element {
             token={baseTokenAddress}
             adornment={adornment}
             color="primary"
+            size="xs"
             isOutOfRange={isOutOfRange}
             className={className}
           />
@@ -63,7 +64,7 @@ export const Footer = memo(function Footer(): JSX.Element {
   const lowestPriceDisplay = useMemo(() => {
     return (
       lowestPrice && (
-        <PriceDisplay price={lowestPrice} token={baseTokenAddress} />
+        <PriceDisplay price={lowestPrice} token={baseTokenAddress} size="xs" />
       )
     );
   }, [baseTokenAddress, lowestPrice]);
@@ -74,6 +75,7 @@ export const Footer = memo(function Footer(): JSX.Element {
         <PriceDisplay
           price={highestPrice}
           token={baseTokenAddress}
+          size="xs"
           className="justifyRight"
         />
       )

--- a/src/components/basic/display/BracketsView/Header.tsx
+++ b/src/components/basic/display/BracketsView/Header.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled.div`
 
   .justifyRight {
     text-align: right;
-    justify-content: end;
+    justify-content: flex-end;
   }
 `;
 

--- a/src/components/basic/display/BracketsView/Header.tsx
+++ b/src/components/basic/display/BracketsView/Header.tsx
@@ -18,6 +18,7 @@ const Wrapper = styled.div`
 
   .justifyRight {
     text-align: right;
+    justify-content: end;
   }
 `;
 

--- a/src/components/basic/display/BracketsView/Header.tsx
+++ b/src/components/basic/display/BracketsView/Header.tsx
@@ -1,0 +1,99 @@
+import React, { memo, useContext, useMemo } from "react";
+import styled from "styled-components";
+
+import { TokenDisplay } from "../TokenDisplay";
+
+import { BracketsViewContext } from "./viewer";
+import { NeedleLabel } from "./NeedleLabel";
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 16px;
+  margin-bottom: 0.1em;
+
+  & > * {
+    width: 100%;
+  }
+
+  .justifyRight {
+    text-align: right;
+  }
+`;
+
+const TokenAndLabel = styled.span`
+  display: flex;
+
+  & > :first-child {
+    margin-right: 0.5em;
+  }
+`;
+
+export const Header = memo(function Header(): JSX.Element {
+  const {
+    baseTokenAddress,
+    quoteTokenAddress,
+    needlePosition,
+    lowerThreshold,
+    upperThreshold,
+  } = useContext(BracketsViewContext);
+
+  const baseTokenDisplay = useMemo((): React.ReactNode => {
+    return (
+      baseTokenAddress && <TokenDisplay token={baseTokenAddress} size="sm" />
+    );
+  }, [baseTokenAddress]);
+
+  const quoteTokenDisplay = useMemo((): React.ReactNode => {
+    return (
+      quoteTokenAddress && (
+        <TokenDisplay
+          token={quoteTokenAddress}
+          size="sm"
+          className="justifyRight"
+        />
+      )
+    );
+  }, [quoteTokenAddress]);
+
+  const leftSide = useMemo((): React.ReactNode => {
+    if (needlePosition < 0) {
+      return <NeedleLabel adornment="left" />;
+    } else if (needlePosition === 0) {
+      return <NeedleLabel />;
+    } else if (needlePosition < lowerThreshold) {
+      return (
+        <TokenAndLabel>
+          {baseTokenDisplay}
+          <NeedleLabel />
+        </TokenAndLabel>
+      );
+    } else {
+      return baseTokenDisplay;
+    }
+  }, [baseTokenDisplay, lowerThreshold, needlePosition]);
+
+  const rightSide = useMemo((): React.ReactNode => {
+    if (needlePosition > 100) {
+      return <NeedleLabel adornment="right" className="justifyRight" />;
+    } else if (needlePosition === 100) {
+      return <NeedleLabel className="justifyRight" />;
+    } else if (needlePosition >= upperThreshold) {
+      return (
+        <TokenAndLabel className="justifyRight">
+          <NeedleLabel />
+          {quoteTokenDisplay}
+        </TokenAndLabel>
+      );
+    } else {
+      return quoteTokenDisplay;
+    }
+  }, [needlePosition, quoteTokenDisplay, upperThreshold]);
+
+  return (
+    <Wrapper>
+      {leftSide}
+      {rightSide}
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/Needle.tsx
+++ b/src/components/basic/display/BracketsView/Needle.tsx
@@ -1,0 +1,59 @@
+import React, { memo, useContext } from "react";
+import styled from "styled-components";
+
+import { NeedleLabel } from "./NeedleLabel";
+import { PriceDisplay } from "./PriceDisplay";
+import { BracketsViewContext } from "./viewer";
+
+// TODO: move to const?
+const NEEDLE_BORDER = "1px dashed #008C73";
+
+const Wrapper = styled.div<{ needlePosition: number }>`
+  height: inherit;
+  width: 0;
+
+  border: ${NEEDLE_BORDER};
+  border-top: 0;
+  border-bottom: 0;
+
+  position: absolute;
+  left: ${({ needlePosition }) => needlePosition}%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .price {
+    position: absolute;
+    width: max-content;
+    bottom: -20px;
+  }
+`;
+
+export const Needle = memo(function Needle(): JSX.Element {
+  const { needlePosition = 50, startPrice, baseTokenAddress } = useContext(
+    BracketsViewContext
+  );
+
+  if (needlePosition < 0 || needlePosition >= 100) {
+    return null;
+  }
+
+  return (
+    <Wrapper needlePosition={needlePosition}>
+      {needlePosition >= 20 && needlePosition <= 80 && (
+        <>
+          <NeedleLabel onNeedle />
+          {startPrice && (
+            <PriceDisplay
+              price={startPrice}
+              token={baseTokenAddress}
+              color="primary"
+              className="price"
+            />
+          )}
+        </>
+      )}
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/NeedleLabel.tsx
+++ b/src/components/basic/display/BracketsView/NeedleLabel.tsx
@@ -1,0 +1,36 @@
+import React, { memo, useContext } from "react";
+import styled from "styled-components";
+
+import { Text } from "@gnosis.pm/safe-react-components";
+
+import { BracketsViewContext } from "./viewer";
+
+const Wrapper = styled.span`
+  width: max-content;
+  position: absolute;
+  top: -1.4em;
+`;
+
+type Props = {
+  adornment?: "left" | "right";
+  className?: string;
+  onNeedle?: boolean;
+};
+
+export const NeedleLabel = memo(function NeedleLabel(
+  props: Props
+): JSX.Element {
+  const { adornment, className, onNeedle } = props;
+  const { type } = useContext(BracketsViewContext);
+
+  const label = type === "deploy" ? "START PRICE" : "MARKET PRICE";
+
+  const text = (
+    <Text as="span" size="sm" color="primary" strong className={className}>
+      {adornment === "left" && "<"} {label} {adornment === "right" && ">"}
+    </Text>
+  );
+
+  // Additional wrapper only when text is displayed on Needle for absolute positioning
+  return onNeedle ? <Wrapper className={className}>{text}</Wrapper> : text;
+});

--- a/src/components/basic/display/BracketsView/NeedleLabel.tsx
+++ b/src/components/basic/display/BracketsView/NeedleLabel.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useContext } from "react";
 import styled from "styled-components";
 
-import { Text } from "@gnosis.pm/safe-react-components";
+import { Text } from "components/basic/display/Text";
 
 import { BracketsViewContext } from "./viewer";
 

--- a/src/components/basic/display/BracketsView/PriceDisplay.tsx
+++ b/src/components/basic/display/BracketsView/PriceDisplay.tsx
@@ -44,7 +44,7 @@ export const PriceDisplay = memo(function PriceDisplay(
       <Text size="sm" as="span" color={color}>
         {price}
       </Text>
-      <TokenDisplay token={token} size="sm" color={color} />
+      {token && <TokenDisplay token={token} size="sm" color={color} />}
       {isOutOfRange && (
         <Text size="sm" color="rinkeby">
           (out of range)

--- a/src/components/basic/display/BracketsView/PriceDisplay.tsx
+++ b/src/components/basic/display/BracketsView/PriceDisplay.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
 import styled from "styled-components";
 
-import { Text } from "@gnosis.pm/safe-react-components";
+import { Text } from "components/basic/display/Text";
 
 import { TokenDisplay } from "../TokenDisplay";
 

--- a/src/components/basic/display/BracketsView/PriceDisplay.tsx
+++ b/src/components/basic/display/BracketsView/PriceDisplay.tsx
@@ -9,6 +9,7 @@ export type Props = {
   price?: string;
   token?: string;
   color?: "primary" | "text";
+  size?: "sm" | "xs";
   className?: string;
   adornment?: "left" | "right";
   isOutOfRange?: boolean;
@@ -30,6 +31,7 @@ export const PriceDisplay = memo(function PriceDisplay(
     token,
     className,
     color = "text",
+    size = "sm",
     adornment,
     isOutOfRange,
   } = props;
@@ -37,21 +39,21 @@ export const PriceDisplay = memo(function PriceDisplay(
   return (
     <Wrapper className={className}>
       {adornment === "left" && (
-        <Text size="sm" as="span" color={color}>
+        <Text size={size} as="span" color={color}>
           &lt;
         </Text>
       )}
-      <Text size="sm" as="span" color={color}>
+      <Text size={size} as="span" color={color}>
         {price}
       </Text>
-      {token && <TokenDisplay token={token} size="sm" color={color} />}
+      {token && <TokenDisplay token={token} size={size} color={color} />}
       {isOutOfRange && (
-        <Text size="sm" color="rinkeby">
+        <Text size={size} color="rinkeby">
           (out of range)
         </Text>
       )}
       {adornment === "right" && (
-        <Text size="sm" as="span" color={color}>
+        <Text size={size} as="span" color={color}>
           &gt;
         </Text>
       )}

--- a/src/components/basic/display/BracketsView/PriceDisplay.tsx
+++ b/src/components/basic/display/BracketsView/PriceDisplay.tsx
@@ -1,0 +1,60 @@
+import React, { memo } from "react";
+import styled from "styled-components";
+
+import { Text } from "@gnosis.pm/safe-react-components";
+
+import { TokenDisplay } from "../TokenDisplay";
+
+export type Props = {
+  price?: string;
+  token?: string;
+  color?: "primary" | "text";
+  className?: string;
+  adornment?: "left" | "right";
+  isOutOfRange?: boolean;
+};
+
+const Wrapper = styled.div`
+  display: flex;
+
+  & > *:not(:last-child) {
+    margin-right: 0.25em;
+  }
+`;
+
+export const PriceDisplay = memo(function PriceDisplay(
+  props: Props
+): JSX.Element {
+  const {
+    price,
+    token,
+    className,
+    color = "text",
+    adornment,
+    isOutOfRange,
+  } = props;
+
+  return (
+    <Wrapper className={className}>
+      {adornment === "left" && (
+        <Text size="sm" as="span" color={color}>
+          &lt;
+        </Text>
+      )}
+      <Text size="sm" as="span" color={color}>
+        {price}
+      </Text>
+      <TokenDisplay token={token} size="sm" color={color} />
+      {isOutOfRange && (
+        <Text size="sm" color="rinkeby">
+          (out of range)
+        </Text>
+      )}
+      {adornment === "right" && (
+        <Text size="sm" as="span" color={color}>
+          &gt;
+        </Text>
+      )}
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/index.tsx
+++ b/src/components/basic/display/BracketsView/index.tsx
@@ -1,0 +1,13 @@
+import React, { memo } from "react";
+
+import { BracketsViewView, Props as ViewerProps } from "./viewer";
+
+export type Props = Omit<ViewerProps, "lowerThreshold" | "upperThreshold">;
+
+export const BracketsViewer = memo(function BracketsViewer(
+  props: Props
+): JSX.Element {
+  // TODO: add logic for fetching market price when type === 'strategy'
+
+  return <BracketsViewView {...props} />;
+});

--- a/src/components/basic/display/BracketsView/viewer.tsx
+++ b/src/components/basic/display/BracketsView/viewer.tsx
@@ -1,151 +1,19 @@
-import React, { memo } from "react";
+import React, { createContext, memo } from "react";
 import styled from "styled-components";
-import { range } from "lodash";
-import { TokenDisplay } from "../TokenDisplay";
-import { Text } from "@gnosis.pm/safe-react-components";
+
+import { Header } from "./Header";
+import { Bar } from "./Bar";
+import { Footer } from "./Footer";
+
+const Wrapper = styled.div`
+  height: 90px;
+`;
 
 type PageType = "deploy" | "strategy";
 
-type WrapperProps = {
-  hasLeft: boolean;
-  needlePosition?: number;
-};
-
-const LEFT_BACKGROUND_COLOR = "rgba(0, 156, 180, 0.1)";
-const RIGHT_BACKGROUND_COLOR = "rgba(128, 94, 255, 0.1)";
-const LEFT_BORDER_LIGHT = "2px solid rgba(0, 156, 180, 0.2)";
-const LEFT_BORDER_THICK = "2px solid #009cb4";
-const RIGHT_BORDER_LIGHT = "2px solid rgba(128, 94, 255, 0.2)";
-const RIGHT_BORDER_THICK = "2px solid #805eff";
-const NEEDLE_BORDER = "1px dashed #008C73";
-
-const Wrapper = styled.div<WrapperProps>`
-  height: 90px;
-
-  /* TODO: Shared between header/footer */
-  .justifyRight {
-    text-align: right;
-    justify-content: right;
-  }
-
-  /* TODO: Header quite similar to footer, refactor single comp */
-  .header {
-    display: flex;
-    justify-content: space-between;
-    height: 16px;
-    margin-bottom: 0.1em;
-
-    & > * {
-      width: 100%;
-    }
-  }
-
-  .footer {
-    display: flex;
-    justify-content: space-between;
-    height: 14px;
-    margin-top: 0.4em;
-
-    & > * {
-      width: 100%;
-    }
-  }
-
-  .bar {
-    width: inherit;
-    height: 46px;
-    position: relative;
-  }
-
-  /* TODO: refactor into own component */
-  ${({ needlePosition = 50 }) => `
-  .needle {
-    height: inherit;
-    width: 0;
-
-    border: ${NEEDLE_BORDER};
-    border-top: 0;
-    border-bottom: 0;
-
-    position: absolute;
-    left: ${needlePosition}%;
-
-    display: flex;
-    flex-direction: column;
-    align-items: ${
-      needlePosition < 20
-        ? "flex-start"
-        : needlePosition > 80
-        ? "flex-end"
-        : "center"
-    };
-
-    .label {
-      text-transform: uppercase;
-
-      position: absolute;
-      width: max-content;
-      top: -1.6em;
-      ${needlePosition < 20 ? `left: 30px;` : ""}
-      ${needlePosition > 80 ? `right: 30px;` : ""}
-    }
-
-    .price {
-      position: absolute;
-      width: max-content;
-      bottom: -20px;
-      ${needlePosition < 20 ? `left: 30px;` : ""}
-      ${needlePosition > 80 ? `right: 30px;` : ""}
-
-    }
-  }
-  `}
-
-  /* TODO: Refactor into own component */
-  .container {
-    height: inherit;
-    display: flex;
-
-    & > * {
-      width: 100%;
-    }
-
-    /* Default to left side color */
-    background-color: ${LEFT_BACKGROUND_COLOR};
-
-    .left:first-of-type {
-      border-left: ${LEFT_BORDER_THICK};
-    }
-
-    .left {
-      border-right: ${LEFT_BORDER_LIGHT};
-    }
-
-    .left:last-of-type {
-      border-right: ${LEFT_BORDER_THICK};
-    }
-
-    ${({ hasLeft }) =>
-      hasLeft
-        ? ""
-        : `
-      .right:first-of-type {
-        border-left: ${RIGHT_BORDER_THICK};
-      }`}
-
-    .right {
-      background-color: ${RIGHT_BACKGROUND_COLOR};
-
-      border-right: ${RIGHT_BORDER_LIGHT};
-    }
-
-    .right:last-of-type {
-      border-right: ${RIGHT_BORDER_THICK};
-    }
-  }
-`;
-
 export type Props = {
+  type: PageType;
+
   baseTokenAddress?: string;
   quoteTokenAddress?: string;
 
@@ -157,52 +25,17 @@ export type Props = {
   startPrice?: string;
   highestPrice?: string;
 
-  type: PageType;
+  lowerThreshold?: number;
+  upperThreshold?: number;
 };
 
-type PriceDisplayProps = {
-  price?: string;
-  token?: string;
-  color?: "primary" | "text";
-  className?: string;
-  adornment?: "left" | "right";
+type ExtraContextProps = {
+  needlePosition?: number;
 };
 
-const PriceDisplayWrapper = styled.div`
-  display: flex;
-
-  & > *:not(:last-child) {
-    margin-right: 0.25em;
-  }
-`;
-
-function PriceDisplay(props: PriceDisplayProps): JSX.Element {
-  const { price, token, className, color = "text", adornment } = props;
-  return (
-    // TODO: clear up inline styles
-    <PriceDisplayWrapper className={className}>
-      {adornment === "left" && (
-        <Text size="sm" as="span" color={color}>
-          &lt;
-        </Text>
-      )}
-      <Text size="sm" as="span" color={color}>
-        {price}
-      </Text>
-      <TokenDisplay token={token} size="sm" color={color} />
-      {!!adornment && (
-        <Text size="sm" color="rinkeby">
-          (out of range)
-        </Text>
-      )}
-      {adornment === "right" && (
-        <Text size="sm" as="span" color={color}>
-          &gt;
-        </Text>
-      )}
-    </PriceDisplayWrapper>
-  );
-}
+export const BracketsViewContext = createContext<Props & ExtraContextProps>({
+  type: "deploy",
+});
 
 /**
  * Calculates needle position as a percentage.
@@ -229,21 +62,8 @@ function calculateNeedlePosition(
   return (100 * (sp - lp)) / (hp - lp);
 }
 
-function NeedleLabel({
-  label,
-  adornment,
-  className,
-}: {
-  label: string;
-  adornment?: "left" | "right";
-  className?: string;
-}): JSX.Element {
-  return (
-    <Text as="span" size="sm" color="primary" strong className={className}>
-      {adornment === "left" && "<"} {label} {adornment === "right" && ">"}
-    </Text>
-  );
-}
+const LOWER_THRESHOLD = 20;
+const UPPER_THRESHOLD = 80;
 
 export const BracketsViewView = memo(function BracketsViewView(
   props: Props
@@ -253,14 +73,12 @@ export const BracketsViewView = memo(function BracketsViewView(
     leftBrackets = 0,
     rightBrackets = 0,
 
-    baseTokenAddress,
-    quoteTokenAddress,
-
     startPrice,
     lowestPrice,
     highestPrice,
 
-    type,
+    lowerThreshold = LOWER_THRESHOLD,
+    upperThreshold = UPPER_THRESHOLD,
   } = props;
 
   const needlePosition = calculateNeedlePosition(
@@ -268,93 +86,26 @@ export const BracketsViewView = memo(function BracketsViewView(
     lowestPrice,
     highestPrice
   );
-  const needleBelow0 = needlePosition && needlePosition < 0;
-  const needleAbove100 = !needleBelow0 && needlePosition > 100;
 
-  const labelText = type === "deploy" ? "START PRICE" : "MARKET PRICE";
+  console.log(`Needle position`, needlePosition);
+
+  const context = {
+    ...props,
+    totalBrackets,
+    leftBrackets,
+    rightBrackets,
+    needlePosition,
+    lowerThreshold,
+    upperThreshold,
+  };
 
   return (
-    <Wrapper hasLeft={!!leftBrackets} needlePosition={needlePosition}>
-      <div className="header">
-        {needleBelow0 ? (
-          <NeedleLabel label={labelText} adornment="left" />
-        ) : (
-          baseTokenAddress && (
-            <TokenDisplay token={baseTokenAddress} size="sm" />
-          )
-        )}
-        {needleAbove100 ? (
-          <NeedleLabel
-            label={labelText}
-            adornment="right"
-            className="justifyRight"
-          />
-        ) : (
-          quoteTokenAddress && (
-            <TokenDisplay
-              token={quoteTokenAddress}
-              size="sm"
-              className="justifyRight"
-            />
-          )
-        )}
-      </div>
-      <div className="bar">
-        {!needleBelow0 && !needleAbove100 && (
-          <div className="needle">
-            <NeedleLabel label={labelText} className="label" />
-            {startPrice && (
-              <PriceDisplay
-                price={startPrice}
-                token={baseTokenAddress}
-                color="primary"
-                className="price"
-              />
-            )}
-          </div>
-        )}
-        <div className="container">
-          {range(
-            !leftBrackets && !rightBrackets ? totalBrackets : leftBrackets
-          ).map((id) => (
-            <div className="left" key={id} />
-          ))}
-          {range(rightBrackets).map((id) => (
-            <div className="right" key={id + leftBrackets} />
-          ))}
-        </div>
-      </div>
-      <div className="footer">
-        {needleBelow0
-          ? startPrice && (
-              <PriceDisplay
-                price={startPrice}
-                token={baseTokenAddress}
-                adornment="left"
-                color="primary"
-              />
-            )
-          : lowestPrice && (
-              <PriceDisplay price={lowestPrice} token={baseTokenAddress} />
-            )}
-        {needleAbove100
-          ? startPrice && (
-              <PriceDisplay
-                price={startPrice}
-                token={baseTokenAddress}
-                adornment="right"
-                color="primary"
-                className="justifyRight"
-              />
-            )
-          : highestPrice && (
-              <PriceDisplay
-                price={highestPrice}
-                token={baseTokenAddress}
-                className="justifyRight"
-              />
-            )}
-      </div>
-    </Wrapper>
+    <BracketsViewContext.Provider value={context}>
+      <Wrapper>
+        <Header />
+        <Bar />
+        <Footer />
+      </Wrapper>
+    </BracketsViewContext.Provider>
   );
 });

--- a/src/components/basic/display/BracketsView/viewer.tsx
+++ b/src/components/basic/display/BracketsView/viewer.tsx
@@ -1,0 +1,186 @@
+import React, { memo } from "react";
+import styled from "styled-components";
+import { range } from "lodash";
+import { TokenDisplay } from "../TokenDisplay";
+import { Text } from "@gnosis.pm/safe-react-components";
+
+type PageType = "deploy" | "strategy";
+
+type WrapperProps = {
+  hasLeft: boolean;
+};
+
+const LEFT_BACKGROUND_COLOR = "rgba(0, 156, 180, 0.1)";
+const RIGHT_BACKGROUND_COLOR = "rgba(128, 94, 255, 0.1)";
+const LEFT_BORDER_LIGHT = "2px solid rgba(0, 156, 180, 0.2)";
+const LEFT_BORDER_THICK = "2px solid #009cb4";
+const RIGHT_BORDER_LIGHT = "2px solid rgba(128, 94, 255, 0.2)";
+const RIGHT_BORDER_THICK = "2px solid #805eff";
+const MIDDLE_BORDER = "";
+
+const Wrapper = styled.div<WrapperProps>`
+  height: 90px;
+
+  /* TODO: Shared between header/footer */
+  .justifyRight {
+    text-align: right;
+    justify-content: right;
+  }
+
+  /* TODO: Header quite similar to footer, refactor single comp */
+  .header {
+    display: flex;
+    justify-content: space-between;
+    height: 16px;
+    margin-bottom: 0.1em;
+
+    & > * {
+      width: 100%;
+    }
+  }
+
+  .footer {
+    display: flex;
+    justify-content: space-between;
+    height: 14px;
+    margin-top: 0.4em;
+
+    & > * {
+      width: 100%;
+    }
+  }
+
+  /* TODO: Refactor into own component */
+  .container {
+    width: inherit;
+    height: 46px;
+
+    display: flex;
+
+    & > * {
+      width: 100%;
+    }
+
+    /* Default to left side color */
+    background-color: ${LEFT_BACKGROUND_COLOR};
+
+    .left:first-of-type {
+      border-left: ${LEFT_BORDER_THICK};
+    }
+
+    .left {
+      border-right: ${LEFT_BORDER_LIGHT};
+    }
+
+    .left:last-of-type {
+      border-right: ${LEFT_BORDER_THICK};
+    }
+
+    ${({ hasLeft }) =>
+      hasLeft
+        ? ""
+        : `
+      .right:first-of-type {
+        border-left: ${RIGHT_BORDER_THICK};
+      }`}
+
+    .right {
+      background-color: ${RIGHT_BACKGROUND_COLOR};
+
+      border-right: ${RIGHT_BORDER_LIGHT};
+    }
+
+    .right:last-of-type {
+      border-right: ${RIGHT_BORDER_THICK};
+    }
+  }
+`;
+
+export type Props = {
+  baseTokenAddress?: string;
+  quoteTokenAddress?: string;
+
+  totalBrackets?: number;
+  leftBrackets?: number;
+  rightBrackets?: number;
+
+  lowestPrice?: string;
+  startPrice?: string;
+  highestPrice?: string;
+
+  type: PageType;
+};
+
+type PriceDisplayProps = {
+  price?: string;
+  token?: string;
+  className?: string;
+};
+
+function PriceDisplay(props: PriceDisplayProps): JSX.Element {
+  const { price, token, className } = props;
+  return (
+    // TODO: clear up inline styles
+    <div className={className} style={{ display: "flex" }}>
+      <Text size="sm" as="span" style={{ paddingRight: "0.25em" }}>
+        {price}
+      </Text>
+      <TokenDisplay token={token} size="sm" />
+    </div>
+  );
+}
+
+export const BracketsViewView = memo(function BracketsViewView(
+  props: Props
+): JSX.Element {
+  const {
+    totalBrackets = 1,
+    leftBrackets = 0,
+    rightBrackets = 0,
+
+    baseTokenAddress,
+    quoteTokenAddress,
+
+    lowestPrice,
+    highestPrice,
+  } = props;
+
+  return (
+    <Wrapper hasLeft={!!leftBrackets}>
+      <div className="header">
+        {baseTokenAddress && (
+          <TokenDisplay token={baseTokenAddress} size="sm" />
+        )}
+        {quoteTokenAddress && (
+          <TokenDisplay
+            token={quoteTokenAddress}
+            size="sm"
+            className="justifyRight"
+          />
+        )}
+      </div>
+      <div className="container">
+        {range(
+          !leftBrackets && !rightBrackets ? totalBrackets : leftBrackets
+        ).map((id) => (
+          <div className="left" key={id} />
+        ))}
+        {range(rightBrackets).map((id) => (
+          <div className="right" key={id + leftBrackets} />
+        ))}
+      </div>
+      <div className="footer">
+        {lowestPrice && (
+          <PriceDisplay price={lowestPrice} token={baseTokenAddress} />
+        )}
+        {highestPrice && (
+          <PriceDisplay
+            price={highestPrice}
+            token={baseTokenAddress}
+            className="justifyRight"
+          />
+        )}
+      </div>
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/BracketsView/viewer.tsx
+++ b/src/components/basic/display/BracketsView/viewer.tsx
@@ -8,6 +8,7 @@ type PageType = "deploy" | "strategy";
 
 type WrapperProps = {
   hasLeft: boolean;
+  needlePosition?: number;
 };
 
 const LEFT_BACKGROUND_COLOR = "rgba(0, 156, 180, 0.1)";
@@ -16,7 +17,7 @@ const LEFT_BORDER_LIGHT = "2px solid rgba(0, 156, 180, 0.2)";
 const LEFT_BORDER_THICK = "2px solid #009cb4";
 const RIGHT_BORDER_LIGHT = "2px solid rgba(128, 94, 255, 0.2)";
 const RIGHT_BORDER_THICK = "2px solid #805eff";
-const MIDDLE_BORDER = "";
+const NEEDLE_BORDER = "1px dashed #008C73";
 
 const Wrapper = styled.div<WrapperProps>`
   height: 90px;
@@ -50,11 +51,59 @@ const Wrapper = styled.div<WrapperProps>`
     }
   }
 
-  /* TODO: Refactor into own component */
-  .container {
+  .bar {
     width: inherit;
     height: 46px;
+    position: relative;
+  }
 
+  /* TODO: refactor into own component */
+  ${({ needlePosition = 50 }) => `
+  .needle {
+    height: inherit;
+    width: 0;
+
+    border: ${NEEDLE_BORDER};
+    border-top: 0;
+    border-bottom: 0;
+
+    position: absolute;
+    left: ${needlePosition}%;
+
+    display: flex;
+    flex-direction: column;
+    align-items: ${
+      needlePosition < 20
+        ? "flex-start"
+        : needlePosition > 80
+        ? "flex-end"
+        : "center"
+    };
+
+    .label {
+      text-transform: uppercase;
+
+      position: absolute;
+      width: max-content;
+      top: -1.6em;
+      ${needlePosition < 20 ? `left: 30px;` : ""}
+      ${needlePosition > 80 ? `right: 30px;` : ""}
+    }
+
+    .price {
+      position: absolute;
+      width: max-content;
+      bottom: -20px;
+      ${needlePosition < 20 ? `left: 30px;` : ""}
+      ${needlePosition > 80 ? `right: 30px;` : ""}
+
+    }
+  }
+  `}
+
+  /* TODO: Refactor into own component */
+  .container {
+    height: inherit;
     display: flex;
 
     & > * {
@@ -114,19 +163,85 @@ export type Props = {
 type PriceDisplayProps = {
   price?: string;
   token?: string;
+  color?: "primary" | "text";
   className?: string;
+  adornment?: "left" | "right";
 };
 
+const PriceDisplayWrapper = styled.div`
+  display: flex;
+
+  & > *:not(:last-child) {
+    margin-right: 0.25em;
+  }
+`;
+
 function PriceDisplay(props: PriceDisplayProps): JSX.Element {
-  const { price, token, className } = props;
+  const { price, token, className, color = "text", adornment } = props;
   return (
     // TODO: clear up inline styles
-    <div className={className} style={{ display: "flex" }}>
-      <Text size="sm" as="span" style={{ paddingRight: "0.25em" }}>
+    <PriceDisplayWrapper className={className}>
+      {adornment === "left" && (
+        <Text size="sm" as="span" color={color}>
+          &lt;
+        </Text>
+      )}
+      <Text size="sm" as="span" color={color}>
         {price}
       </Text>
-      <TokenDisplay token={token} size="sm" />
-    </div>
+      <TokenDisplay token={token} size="sm" color={color} />
+      {!!adornment && (
+        <Text size="sm" color="rinkeby">
+          (out of range)
+        </Text>
+      )}
+      {adornment === "right" && (
+        <Text size="sm" as="span" color={color}>
+          &gt;
+        </Text>
+      )}
+    </PriceDisplayWrapper>
+  );
+}
+
+/**
+ * Calculates needle position as a percentage.
+ * Percentage can be negative or greater than 100.
+ * Returns undefined when input is invalid
+ *
+ * @param startPrice Start price string
+ * @param lowestPrice Lowest Price string
+ * @param highestPrice Highest Price string
+ */
+function calculateNeedlePosition(
+  startPrice?: string,
+  lowestPrice?: string,
+  highestPrice?: string
+): number | undefined {
+  const sp = Number(startPrice);
+  const lp = Number(lowestPrice);
+  const hp = Number(highestPrice);
+
+  if (isNaN(sp) || isNaN(lp) || isNaN(hp) || lp >= hp) {
+    return undefined;
+  }
+
+  return (100 * (sp - lp)) / (hp - lp);
+}
+
+function NeedleLabel({
+  label,
+  adornment,
+  className,
+}: {
+  label: string;
+  adornment?: "left" | "right";
+  className?: string;
+}): JSX.Element {
+  return (
+    <Text as="span" size="sm" color="primary" strong className={className}>
+      {adornment === "left" && "<"} {label} {adornment === "right" && ">"}
+    </Text>
   );
 }
 
@@ -141,45 +256,104 @@ export const BracketsViewView = memo(function BracketsViewView(
     baseTokenAddress,
     quoteTokenAddress,
 
+    startPrice,
     lowestPrice,
     highestPrice,
+
+    type,
   } = props;
 
+  const needlePosition = calculateNeedlePosition(
+    startPrice,
+    lowestPrice,
+    highestPrice
+  );
+  const needleBelow0 = needlePosition && needlePosition < 0;
+  const needleAbove100 = !needleBelow0 && needlePosition > 100;
+
+  const labelText = type === "deploy" ? "START PRICE" : "MARKET PRICE";
+
   return (
-    <Wrapper hasLeft={!!leftBrackets}>
+    <Wrapper hasLeft={!!leftBrackets} needlePosition={needlePosition}>
       <div className="header">
-        {baseTokenAddress && (
-          <TokenDisplay token={baseTokenAddress} size="sm" />
+        {needleBelow0 ? (
+          <NeedleLabel label={labelText} adornment="left" />
+        ) : (
+          baseTokenAddress && (
+            <TokenDisplay token={baseTokenAddress} size="sm" />
+          )
         )}
-        {quoteTokenAddress && (
-          <TokenDisplay
-            token={quoteTokenAddress}
-            size="sm"
+        {needleAbove100 ? (
+          <NeedleLabel
+            label={labelText}
+            adornment="right"
             className="justifyRight"
           />
+        ) : (
+          quoteTokenAddress && (
+            <TokenDisplay
+              token={quoteTokenAddress}
+              size="sm"
+              className="justifyRight"
+            />
+          )
         )}
       </div>
-      <div className="container">
-        {range(
-          !leftBrackets && !rightBrackets ? totalBrackets : leftBrackets
-        ).map((id) => (
-          <div className="left" key={id} />
-        ))}
-        {range(rightBrackets).map((id) => (
-          <div className="right" key={id + leftBrackets} />
-        ))}
+      <div className="bar">
+        {!needleBelow0 && !needleAbove100 && (
+          <div className="needle">
+            <NeedleLabel label={labelText} className="label" />
+            {startPrice && (
+              <PriceDisplay
+                price={startPrice}
+                token={baseTokenAddress}
+                color="primary"
+                className="price"
+              />
+            )}
+          </div>
+        )}
+        <div className="container">
+          {range(
+            !leftBrackets && !rightBrackets ? totalBrackets : leftBrackets
+          ).map((id) => (
+            <div className="left" key={id} />
+          ))}
+          {range(rightBrackets).map((id) => (
+            <div className="right" key={id + leftBrackets} />
+          ))}
+        </div>
       </div>
       <div className="footer">
-        {lowestPrice && (
-          <PriceDisplay price={lowestPrice} token={baseTokenAddress} />
-        )}
-        {highestPrice && (
-          <PriceDisplay
-            price={highestPrice}
-            token={baseTokenAddress}
-            className="justifyRight"
-          />
-        )}
+        {needleBelow0
+          ? startPrice && (
+              <PriceDisplay
+                price={startPrice}
+                token={baseTokenAddress}
+                adornment="left"
+                color="primary"
+              />
+            )
+          : lowestPrice && (
+              <PriceDisplay price={lowestPrice} token={baseTokenAddress} />
+            )}
+        {needleAbove100
+          ? startPrice && (
+              <PriceDisplay
+                price={startPrice}
+                token={baseTokenAddress}
+                adornment="right"
+                color="primary"
+                className="justifyRight"
+              />
+            )
+          : highestPrice && (
+              <PriceDisplay
+                price={highestPrice}
+                token={baseTokenAddress}
+                className="justifyRight"
+              />
+            )}
       </div>
     </Wrapper>
   );

--- a/src/components/basic/display/BracketsView/viewer.tsx
+++ b/src/components/basic/display/BracketsView/viewer.tsx
@@ -90,7 +90,7 @@ export const BracketsViewView = memo(function BracketsViewView(
   const context = useMemo(
     () => ({
       ...props,
-      totalBrackets,
+      totalBrackets: totalBrackets >= 1 ? totalBrackets : 1,
       leftBrackets,
       rightBrackets,
       needlePosition,

--- a/src/components/basic/display/BracketsView/viewer.tsx
+++ b/src/components/basic/display/BracketsView/viewer.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, memo } from "react";
+import React, { createContext, memo, useMemo } from "react";
 import styled from "styled-components";
 
 import { Header } from "./Header";
@@ -81,23 +81,32 @@ export const BracketsViewView = memo(function BracketsViewView(
     upperThreshold = UPPER_THRESHOLD,
   } = props;
 
-  const needlePosition = calculateNeedlePosition(
-    startPrice,
-    lowestPrice,
-    highestPrice
+  const needlePosition = useMemo(
+    (): number | undefined =>
+      calculateNeedlePosition(startPrice, lowestPrice, highestPrice),
+    [highestPrice, lowestPrice, startPrice]
   );
 
-  console.log(`Needle position`, needlePosition);
-
-  const context = {
-    ...props,
-    totalBrackets,
-    leftBrackets,
-    rightBrackets,
-    needlePosition,
-    lowerThreshold,
-    upperThreshold,
-  };
+  const context = useMemo(
+    () => ({
+      ...props,
+      totalBrackets,
+      leftBrackets,
+      rightBrackets,
+      needlePosition,
+      lowerThreshold,
+      upperThreshold,
+    }),
+    [
+      leftBrackets,
+      lowerThreshold,
+      needlePosition,
+      props,
+      rightBrackets,
+      totalBrackets,
+      upperThreshold,
+    ]
+  );
 
   return (
     <BracketsViewContext.Provider value={context}>

--- a/src/components/basic/display/Message/Message.stories.tsx
+++ b/src/components/basic/display/Message/Message.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Meta } from "@storybook/react";
 
+import { Text } from "components/basic/display/Text";
+
 import { Message, Props } from ".";
-import { Text } from "@gnosis.pm/safe-react-components";
 
 export default {
   component: Message,
@@ -35,9 +36,9 @@ export const WithComponentChildren = Template.bind({});
 WithComponentChildren.args = {
   ...Default.args,
   children: (
-    <Text size="sm" color="shadow">
+    <Text color="shadow">
       The specified{" "}
-      <Text size="sm" strong as="span">
+      <Text strong as="span">
         Start Price
       </Text>{" "}
       is at least 2% higher than the current indicated market price. If

--- a/src/components/basic/display/Message/index.tsx
+++ b/src/components/basic/display/Message/index.tsx
@@ -1,6 +1,8 @@
 import React, { memo, useMemo } from "react";
 import styled from "styled-components";
-import { Icon, Text } from "@gnosis.pm/safe-react-components";
+import { Icon } from "@gnosis.pm/safe-react-components";
+
+import { Text } from "components/basic/display/Text";
 
 import { theme } from "theme";
 

--- a/src/components/basic/display/SubtextAmount/index.tsx
+++ b/src/components/basic/display/SubtextAmount/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
 import styled from "styled-components";
 
-import { Text } from "@gnosis.pm/safe-react-components";
+import { Text } from "components/basic/display/Text";
 
 interface WrapperProps {
   inline?: boolean;

--- a/src/components/basic/display/Text/Text.stories.tsx
+++ b/src/components/basic/display/Text/Text.stories.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+
+import { Props, Text } from ".";
+
+export default {
+  component: Text,
+  title: "basic/display/Text",
+} as Meta;
+
+const Template: Story<Props> = (args) => <Text {...args} />;
+
+export const Default = Template.bind({});
+Default.args = { children: "Default text" };
+
+export const Xs = Template.bind({});
+Xs.args = { children: "Extra small", size: "xs" };
+
+export const Lg = Template.bind({});
+Lg.args = { children: "Large", size: "lg" };
+
+export const Xl = Template.bind({});
+Xl.args = { children: "Extra Large", size: "xl" };

--- a/src/components/basic/display/Text/index.tsx
+++ b/src/components/basic/display/Text/index.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import styled from "styled-components";
+
+import { Text as SRCText } from "@gnosis.pm/safe-react-components";
+import { ThemeTextSize } from "@gnosis.pm/safe-react-components/dist/theme";
+
+import { theme } from "theme";
+
+type OverwrittenSize = { size?: ThemeTextSize | "xs" };
+
+export type Props = Omit<React.ComponentProps<typeof SRCText>, "size"> &
+  OverwrittenSize;
+
+const ReStyledText = styled(SRCText)<OverwrittenSize>`
+  font-size: ${({ size }) => `${theme.text.size[size].fontSize}`};
+  line-height: ${({ size }) => `${theme.text.size[size].lineHeight}`};
+`;
+
+/**
+ * Overwrites Safe React Components <Text/> to introduce on extra size: `xs`
+ */
+export const Text = (props: Props): React.ReactElement => {
+  const { children, size = "sm", as, ...rest } = props;
+
+  return (
+    <ReStyledText {...rest} size={size} forwardedAs={as}>
+      {children}
+    </ReStyledText>
+  );
+};

--- a/src/components/basic/display/TokenDisplay/index.tsx
+++ b/src/components/basic/display/TokenDisplay/index.tsx
@@ -12,6 +12,7 @@ export interface Props {
   token: string;
   size: ThemeTextSize;
   color?: ThemeColors;
+  className?: string;
 }
 
 /**
@@ -25,19 +26,19 @@ export interface Props {
 export const TokenDisplay = memo(function TokenDisplay(
   props: Props
 ): JSX.Element {
-  const { token, size, color } = props;
+  const { token, size, color, className } = props;
 
   // TODO: handle error
   const { tokenDetails, isLoading } = useTokenDetails(token);
 
   return tokenDetails ? (
-    <Text size={size} color={color} strong as="span">
+    <Text size={size} color={color} strong as="span" className={className}>
       {tokenDetails.symbol}
     </Text>
   ) : isLoading ? (
-    <Loader size={size === "xl" ? "lg" : size} />
+    <Loader size={size === "xl" ? "lg" : size} className={className} />
   ) : (
-    <Text size={size} color={color} strong as="span">
+    <Text size={size} color={color} strong as="span" className={className}>
       -
     </Text>
   );

--- a/src/components/basic/display/TokenDisplay/index.tsx
+++ b/src/components/basic/display/TokenDisplay/index.tsx
@@ -1,12 +1,13 @@
 import React, { memo } from "react";
 
-import { Text, Loader } from "@gnosis.pm/safe-react-components";
-import {
-  ThemeTextSize,
-  ThemeColors,
-} from "@gnosis.pm/safe-react-components/dist/theme";
+import { Loader } from "@gnosis.pm/safe-react-components";
+import { ThemeColors } from "@gnosis.pm/safe-react-components/dist/theme";
 
 import { useTokenDetails } from "hooks/useTokenDetails";
+
+import { ThemeTextSize } from "theme";
+
+import { Text } from "components/basic/display/Text";
 
 export interface Props {
   token: string;

--- a/src/components/basic/inputs/FundingInput/Label.tsx
+++ b/src/components/basic/inputs/FundingInput/Label.tsx
@@ -1,8 +1,7 @@
 import React, { memo } from "react";
 import styled from "styled-components";
 
-import { Text } from "@gnosis.pm/safe-react-components";
-
+import { Text } from "components/basic/display/Text";
 import { ButtonLink } from "components/basic/inputs/ButtonLink";
 
 const Wrapper = styled.span`

--- a/src/components/basic/inputs/Link/index.tsx
+++ b/src/components/basic/inputs/Link/index.tsx
@@ -1,7 +1,8 @@
 import React, { ComponentPropsWithoutRef, memo } from "react";
 import styled from "styled-components";
 
-import { Text } from "@gnosis.pm/safe-react-components";
+import { Text } from "components/basic/display/Text";
+
 import { theme } from "theme";
 
 import { Props as ButtonLinkProps } from "components/basic/inputs/ButtonLink";

--- a/src/components/pages/deploy/BracketsViewFragment.tsx
+++ b/src/components/pages/deploy/BracketsViewFragment.tsx
@@ -4,6 +4,8 @@ import { useFormState } from "react-final-form";
 
 import { BracketsViewer } from "components/basic/display/BracketsView";
 
+import { theme } from "theme";
+
 import { getBracketValue } from "./DeployForm";
 import { DeployFormValues } from "./types";
 
@@ -11,7 +13,7 @@ const Wrapper = styled.div`
   width: 450px;
   heigh: 115px;
 
-  background-color: #f7f5f5;
+  background-color: ${theme.colors.backgroundSideBar};
   border-radius: 16px;
 
   & > * {

--- a/src/components/pages/deploy/BracketsViewFragment.tsx
+++ b/src/components/pages/deploy/BracketsViewFragment.tsx
@@ -1,0 +1,48 @@
+import React, { memo, useMemo } from "react";
+import styled from "styled-components";
+import { useFormState } from "react-final-form";
+
+import { BracketsViewer } from "components/basic/display/BracketsView";
+
+import { getBracketValue } from "./DeployForm";
+import { DeployFormValues } from "./types";
+
+const Wrapper = styled.div`
+  width: 450px;
+  heigh: 115px;
+
+  background-color: #f7f5f5;
+  border-radius: 16px;
+
+  & > * {
+    padding: 17px 15px 10px;
+  }
+`;
+
+export const BracketsViewFragment = memo(
+  function BracketsViewFragment(): JSX.Element {
+    const { values } = useFormState<DeployFormValues>();
+
+    const totalBrackets = Number(values.totalBrackets);
+    const leftBrackets = useMemo(
+      () => getBracketValue(values.calculatedBrackets, "base"),
+      [values.calculatedBrackets]
+    );
+    const rightBrackets = useMemo(
+      () => getBracketValue(values.calculatedBrackets, "quote"),
+      [values.calculatedBrackets]
+    );
+
+    return (
+      <Wrapper>
+        <BracketsViewer
+          type="deploy"
+          {...values}
+          leftBrackets={leftBrackets}
+          rightBrackets={rightBrackets}
+          totalBrackets={totalBrackets}
+        />
+      </Wrapper>
+    );
+  }
+);

--- a/src/components/pages/deploy/viewer.tsx
+++ b/src/components/pages/deploy/viewer.tsx
@@ -9,10 +9,20 @@ import { ErrorMessagesFragment } from "./ErrorMessagesFragment";
 import { DeployStrategyButtonFragment } from "./DeployStrategyButtonFragment";
 import { DeployForm } from "./DeployForm";
 import { FormBackdrop } from "./FormBackdrop";
+import { BracketsViewFragment } from "./BracketsViewFragment";
 
 const PageLayout = styled.div`
   display: flex;
   min-width: 860px;
+`;
+
+const DeployColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  /* Some space for sidebar */
+  margin-right: 48px;
 `;
 
 const DeployWidget = styled.div`
@@ -21,9 +31,6 @@ const DeployWidget = styled.div`
   min-height: 482px;
 
   padding: 16px 13px;
-
-  // Some space for sidebar
-  margin-right: 48px;
 
   // Spacing between elements
   & > *:not(:last-child) {
@@ -44,14 +51,17 @@ export const DeployPageViewer = memo(function DeployPageViewer(): JSX.Element {
   return (
     <PageLayout>
       <DeployForm>
-        <DeployWidget>
-          <TokenSelectorsFragment />
-          <MarketPriceFragment />
-          <PricesFragment />
-          <ErrorMessagesFragment />
-          <DeployStrategyButtonFragment />
-        </DeployWidget>
-        <FormBackdrop />
+        <DeployColumn>
+          <DeployWidget>
+            <TokenSelectorsFragment />
+            <MarketPriceFragment />
+            <PricesFragment />
+            <ErrorMessagesFragment />
+            <DeployStrategyButtonFragment />
+          </DeployWidget>
+          <BracketsViewFragment />
+          <FormBackdrop />
+        </DeployColumn>
       </DeployForm>
       <SideBar />
     </PageLayout>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@ import { theme as srcTheme } from "@gnosis.pm/safe-react-components";
 
 type themeType = typeof srcTheme;
 type colorsType = typeof srcTheme.colors;
+type textType = typeof srcTheme.text;
 
 const backgroundColors = {
   backgroundError: "#FFE6EA",
@@ -9,11 +10,23 @@ const backgroundColors = {
   backgroundSideBar: "#F7F5F5",
 };
 
+const xsTextSize = {
+  xs: {
+    fontSize: "10px",
+    lineHeight: "14px",
+  },
+};
+
 export interface Theme extends themeType {
   colors: colorsType & typeof backgroundColors;
+  text: textType & { size: typeof xsTextSize };
 }
 
 export const theme: Theme = {
   ...srcTheme,
   colors: { ...srcTheme.colors, ...backgroundColors },
+  text: { ...srcTheme.text, size: { ...srcTheme.text.size, ...xsTextSize } },
 };
+
+export type ThemeTextSize = keyof typeof theme["text"]["size"];
+export type ThemeColors = keyof typeof theme["colors"];


### PR DESCRIPTION
# Description

Part of #94 

Added brackets visualization to deploy page
![screenshot_2020-10-14_13-52-41](https://user-images.githubusercontent.com/43217/96043923-7d603280-0e24-11eb-870d-85fd4b57a7d8.png)

# To Test
1. Open the app

- [ ] Deploy page should display an empty brackets visualization such as
![screenshot_2020-10-14_13-53-53](https://user-images.githubusercontent.com/43217/96044042-abde0d80-0e24-11eb-8795-be8bb8a13694.png)

- [ ] Fill in various fields and check visualization match data input
  - [ ] Supports partial data (only one price, no tokens selected, etc)
  - [ ] Left side brackets are displayed in light green, matching the amount of brackets on the left side
![screenshot_2020-10-14_14-00-10](https://user-images.githubusercontent.com/43217/96044641-96b5ae80-0e25-11eb-8f35-847c2b1a9069.png)
  - [ ] Right side brackets are displayed in light purple, matching the amount of brackets on the right side
![screenshot_2020-10-14_14-00-21](https://user-images.githubusercontent.com/43217/96044648-9a493580-0e25-11eb-90f6-1df79163d5a4.png)
  - [ ] Number of divisions in the bar match total number of brackets
![screenshot_2020-10-14_14-00-31](https://user-images.githubusercontent.com/43217/96044656-9ddcbc80-0e25-11eb-91fb-e5b0487b6db6.png)


# Background

- Semi-ready to be added to strategies page (Some tweaking required, will work it as another PR).
- Felt really slow for me. Not sure this is horribly implemented or my computer is super slow at the moment. Might need to revisit to improve performance.


