### PR TITLE
Feature/#94/add brackets visualization to active strategy

### DIFF
--- a/src/components/basic/display/BracketsView/index.tsx
+++ b/src/components/basic/display/BracketsView/index.tsx
@@ -34,7 +34,7 @@ export const BracketsViewer = memo(function BracketsViewer(
     isStrategy ? quoteTokenAddress : undefined
   );
   const { price } = useGetPrice({ baseToken, quoteToken });
-  const marketPrice = price?.toString() || "N/A";
+  const marketPrice = price?.isFinite() ? price.toString() : "N/A";
 
   // Calculate brackets, only if on Strategy page (marketPrice)
   const { baseTokenBrackets, quoteTokenBrackets } = calculateBrackets({

--- a/src/components/pages/strategies/Active/ActiveTable.tsx
+++ b/src/components/pages/strategies/Active/ActiveTable.tsx
@@ -118,7 +118,9 @@ export const ActiveTable = memo(function ActiveTable({
                 }
               >
                 <TableCell colSpan={9} key={strategy.transactionHash}>
-                  <Details strategy={strategy} />
+                  {foldOutStrategy === strategy.transactionHash && (
+                    <Details strategy={strategy} />
+                  )}
                 </TableCell>
               </HideableTableRow>
             </>

--- a/src/components/pages/strategies/Active/Details.tsx
+++ b/src/components/pages/strategies/Active/Details.tsx
@@ -1,56 +1,71 @@
 import React, { memo, useCallback, useState } from "react";
+import styled from "styled-components";
+import { Box, ButtonGroup } from "@material-ui/core";
 
 import Strategy from "logic/strategy";
-import { Box, ButtonGroup } from "@material-ui/core";
 import { Button } from "components/basic/inputs/Button";
 
-import { Props as SafeComponentButtonProps } from "@gnosis.pm/safe-react-components/dist/inputs/Button";
+import { StrategyTab } from "./StrategyTab";
 
-// I hate this
-type OldPropsWithoutColor = Omit<SafeComponentButtonProps, "color">;
-type SafeButtonProps = OldPropsWithoutColor & { color: string };
+const TabContents = styled.div`
+  padding: 35px 0;
+`;
 
 export interface Props {
   strategy: Strategy;
 }
 
-export const Details = memo(function Details({ strategy }: Props): JSX.Element {
-  const [activeDetailScreen, setActiveDetailScreen] = useState(null);
+type TabNames = "strategy" | "trades" | "params";
 
-  const makeTabChangeHandler = useCallback((tabName): (() => void) => {
-    return () => {
-      setActiveDetailScreen(tabName);
-    };
-  }, []);
+export const Details = memo(function Details({ strategy }: Props): JSX.Element {
+  const [activeDetailScreen, setActiveDetailScreen] = useState<TabNames>(
+    "strategy"
+  );
+
+  const makeTabChangeHandler = useCallback(
+    (tabName: TabNames): (() => void) => {
+      return () => {
+        setActiveDetailScreen(tabName);
+      };
+    },
+    []
+  );
 
   return (
-    <Box>
-      <ButtonGroup>
-        <Button
-          size="md"
-          variant="contained"
-          onClick={makeTabChangeHandler("strategy")}
-          color={activeDetailScreen === "strategy" ? "primary" : "white"}
-        >
-          Strategy
-        </Button>
-        <Button
-          size="md"
-          variant="contained"
-          onClick={makeTabChangeHandler("trades")}
-          color={activeDetailScreen === "trades" ? "primary" : "white"}
-        >
-          Trades
-        </Button>
-        <Button
-          size="md"
-          variant="contained"
-          onClick={makeTabChangeHandler("params")}
-          color={activeDetailScreen === "params" ? "primary" : "white"}
-        >
-          Deployed Params.
-        </Button>
-      </ButtonGroup>
-    </Box>
+    <>
+      <Box>
+        <ButtonGroup>
+          <Button
+            size="md"
+            variant="contained"
+            onClick={makeTabChangeHandler("strategy")}
+            color={activeDetailScreen === "strategy" ? "primary" : "white"}
+          >
+            Strategy
+          </Button>
+          <Button
+            size="md"
+            variant="contained"
+            onClick={makeTabChangeHandler("trades")}
+            color={activeDetailScreen === "trades" ? "primary" : "white"}
+          >
+            Trades
+          </Button>
+          <Button
+            size="md"
+            variant="contained"
+            onClick={makeTabChangeHandler("params")}
+            color={activeDetailScreen === "params" ? "primary" : "white"}
+          >
+            Deployed Params.
+          </Button>
+        </ButtonGroup>
+      </Box>
+      <TabContents>
+        {activeDetailScreen === "strategy" && (
+          <StrategyTab strategy={strategy} />
+        )}
+      </TabContents>
+    </>
   );
 });

--- a/src/components/pages/strategies/Active/StrategyTab.tsx
+++ b/src/components/pages/strategies/Active/StrategyTab.tsx
@@ -1,0 +1,30 @@
+import React, { memo } from "react";
+import styled from "styled-components";
+
+import Strategy from "logic/strategy";
+import { BracketsViewer } from "components/basic/display/BracketsView";
+
+export type Props = {
+  strategy: Strategy;
+};
+
+const Wrapper = styled.div``;
+
+export const StrategyTab = memo(function StrategyTab(
+  props: Props
+): JSX.Element {
+  const { strategy } = props;
+
+  return (
+    <Wrapper>
+      <BracketsViewer
+        type="strategy"
+        baseTokenAddress={strategy.baseTokenAddress}
+        quoteTokenAddress={strategy.quoteTokenAddress}
+        lowestPrice={strategy.priceRange?.lower.toString()}
+        highestPrice={strategy.priceRange?.upper.toString()}
+        totalBrackets={strategy.brackets?.length}
+      />
+    </Wrapper>
+  );
+});


### PR DESCRIPTION
# Description

Continuing #94 

Added brackets visualization to active strategy tab
![screenshot_2020-10-21_15-06-58](https://user-images.githubusercontent.com/43217/96792319-03ddbc80-13af-11eb-8a11-d17a52b86254.png)


# To Test
1. Make sure you have at least one strategy deployed.
1. Head to `Strategies` page
1. Expand one strategy

- [ ] Should display the brackets visualization for this strategy
- [ ] Bracket color should change when hovering over it

# Background

- Market price calculated using 1inch. Will have the same limitations as prices displayed on `Deploy` page
