### PR TITLE
Fetch exchange id

### DIFF
--- a/src/api/safe/index.ts
+++ b/src/api/safe/index.ts
@@ -14,10 +14,22 @@ export const getTransactions = async (
   return txs.results;
 };
 
+type SafeTokenDetails = {
+  name: string;
+  symbol: string;
+  decimals: number;
+  logoUri: string;
+};
+type SafeBalance = {
+  tokenAddress: null | string;
+  token: null | SafeTokenDetails;
+  balance: string;
+};
+
 export const getBalances = async (
   network: string,
   safeAddress: string
-): Promise<any> => {
+): Promise<SafeBalance[]> => {
   const safeEndpoint = getSafeEndpoint(network);
   const response = await fetch(
     `${safeEndpoint}/api/v1/safes/${safeAddress}/balances`

--- a/src/api/tokenAddresses.ts
+++ b/src/api/tokenAddresses.ts
@@ -22,6 +22,7 @@ const tokenAddresses: { [networkId: number]: string[] } = {
     "0x784B46A4331f5c7C495F296AE700652265ab2fC6", // gusd
     "0xBD6A9921504fae42EaD2024F43305A8ED3890F6f", // pax
     "0xa9881E6459CA05d7D7C95374463928369cD7a90C", // usdt
+    "0xa3a0b8ce8aed4d90362782758767e3a0bb9ffdd5", // uni --- not registered, here to test only
   ],
   [Network.xdai]: [
     "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb", // GNO

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface TokenDetails {
   name: string;
   imageUrl?: string;
   onGP?: boolean;
+  id?: number;
 }
 
 export interface SafeInfo {


### PR DESCRIPTION
# Description

Fetch exchange id together with other Erc20 details.

# To Test
No UI changes

On page load, the console should print the exchange id as part of the token details, both for Safe tokens:
![screenshot_2020-11-04_13-11-39](https://user-images.githubusercontent.com/43217/98168280-36071800-1e9f-11eb-9790-27475da1c734.png)

and for additional tokens:
![screenshot_2020-11-04_13-12-09](https://user-images.githubusercontent.com/43217/98168320-44edca80-1e9f-11eb-9756-1b0c3f8daf6a.png)

Given `id` should match the one in the contract for the same address and network.
Example, USDC on Rinkeby:
![screenshot_2020-11-04_13-13-36](https://user-images.githubusercontent.com/43217/98168524-8a11fc80-1e9f-11eb-934e-1f56d3ae882d.png)


# Background

Required step to fetch GP prices

