### PR TITLE
Feature/#98/strategy total value

### DIFF
--- a/src/api/tokenAddresses.ts
+++ b/src/api/tokenAddresses.ts
@@ -30,6 +30,7 @@ const tokenAddresses: { [networkId: number]: string[] } = {
     "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d", // wxDai
     "0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e", // STAKE
     "0xB1950Fb2C9C0CbC8553578c67dB52Aa110A93393", // sUSD
+    "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83", // USDC
   ],
 };
 

--- a/src/components/basic/display/Arrow/Arrow.stories.tsx
+++ b/src/components/basic/display/Arrow/Arrow.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react/types-6-0";
+
+import { Arrow, Props } from ".";
+
+export default {
+  component: Arrow,
+  title: "basic/display/Arrow",
+} as Meta;
+
+const Template: Story<Props> = (props) => <Arrow {...props} />;
+
+const defaultData: Props = { color: "roiApyPositive" };
+
+export const Default = Template.bind({});
+Default.args = { ...defaultData };
+
+export const ArrowDown = Template.bind({});
+ArrowDown.args = { ...defaultData, direction: "down", color: "roiApyNegative" };

--- a/src/components/basic/display/Arrow/index.tsx
+++ b/src/components/basic/display/Arrow/index.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components";
+import { ThemeColors } from "theme";
+
+const Wrapper = styled.div<Props>`
+  width: 0;
+  height: 0;
+
+  ${({ size = "sm", direction = "up", color = "text", theme }) => `
+  border-left: ${sizes[size]} solid transparent;
+  border-right: ${sizes[size]} solid transparent;
+
+  border-${direction === "up" ? "bottom" : "top"}: calc(${
+    sizes[size]
+  } * 1.4) solid ${theme.colors[color || "text"]};
+  `}
+`;
+
+const sizes = {
+  xs: "5px",
+  sm: "10px",
+  md: "15px",
+  lg: "20px",
+};
+
+type Size = keyof typeof sizes;
+
+export type Props = {
+  direction?: "up" | "down";
+  color?: ThemeColors;
+  size?: Size;
+  className?: string;
+};
+
+export function Arrow(props: Props): JSX.Element {
+  return <Wrapper {...props} />;
+}

--- a/src/components/basic/display/StrategyTotalValue/DetailsTable.tsx
+++ b/src/components/basic/display/StrategyTotalValue/DetailsTable.tsx
@@ -1,0 +1,55 @@
+import React, { memo } from "react";
+import Decimal from "decimal.js";
+import styled from "styled-components";
+
+import { formatSmart } from "utils/format";
+
+import { Text } from "components/basic/display/Text";
+
+import { PercentageIndicator } from "./PercentageIndicator";
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-areas: "title value";
+  grid-column-gap: 12px;
+
+  align-items: center;
+
+  .title {
+    justify-self: right;
+  }
+
+  .value {
+    justify-self: left;
+  }
+`;
+
+export type Props = { holdValue: Decimal; roi?: Decimal; apy?: Decimal };
+
+export const DetailsTable = memo(function DetailsTable(
+  props: Props
+): JSX.Element {
+  const { holdValue, roi, apy } = props;
+
+  return (
+    <Wrapper>
+      <Text className="title" color="textGrey" size="xs" as="span">
+        HODL VALUE
+      </Text>
+      <Text className="value" size="lg" as="span" strong>
+        ${formatSmart(holdValue)}
+      </Text>
+
+      <Text className="title" color="textGrey" size="xs" as="span">
+        ROI
+      </Text>
+      <PercentageIndicator className="value" value={roi} size="lg" />
+
+      <Text className="title" color="textGrey" size="xs" as="span">
+        APY
+      </Text>
+      <PercentageIndicator className="value" value={apy} size="lg" />
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/StrategyTotalValue/DetailsTable.tsx
+++ b/src/components/basic/display/StrategyTotalValue/DetailsTable.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.div`
   }
 `;
 
-export type Props = { holdValue: Decimal; roi?: Decimal; apy?: Decimal };
+export type Props = { holdValue?: Decimal; roi?: Decimal; apy?: Decimal };
 
 export const DetailsTable = memo(function DetailsTable(
   props: Props
@@ -38,7 +38,7 @@ export const DetailsTable = memo(function DetailsTable(
         HODL VALUE
       </Text>
       <Text className="value" size="lg" as="span" strong>
-        ${formatSmart(holdValue)}
+        {holdValue ? `$${formatSmart(holdValue)}` : "N/A"}
       </Text>
 
       <Text className="title" color="textGrey" size="xs" as="span">

--- a/src/components/basic/display/StrategyTotalValue/PercentageIndicator.tsx
+++ b/src/components/basic/display/StrategyTotalValue/PercentageIndicator.tsx
@@ -1,0 +1,61 @@
+import React, { memo } from "react";
+import Decimal from "decimal.js";
+import styled from "styled-components";
+
+import { ThemeTextSize } from "theme";
+
+import { ONE_HUNDRED_DECIMAL, ZERO_DECIMAL } from "utils/constants";
+
+import { Text } from "components/basic/display/Text";
+import { Arrow } from "components/basic/display/Arrow";
+
+const Wrapper = styled.div<{ isPositive: boolean }>`
+  display: flex;
+  align-items: center;
+
+  & > :last-child {
+    margin-left: 2px;
+  }
+`;
+
+export type Props = {
+  value?: Decimal;
+  className?: string;
+  size?: ThemeTextSize;
+};
+
+function formatValue(value: Decimal): string {
+  return `${value.mul(ONE_HUNDRED_DECIMAL).toFixed(2)}%`;
+}
+
+export const PercentageIndicator = memo(function PercentageIndicator(
+  props: Props
+): JSX.Element {
+  const { value, size, className } = props;
+
+  if (!value) {
+    return <Text>N/A</Text>;
+  }
+
+  const isPositive = value.gte(ZERO_DECIMAL);
+  const displayValue = (isPositive ? "+" : "") + formatValue(value);
+
+  return (
+    <Wrapper className={className} isPositive={isPositive}>
+      <Text
+        color={isPositive ? "roiApyPositive" : "roiApyNegative"}
+        size={size}
+        strong
+        as="span"
+      >
+        {displayValue}
+      </Text>
+      <Arrow
+        size="xs"
+        className="icon"
+        direction={isPositive ? "up" : "down"}
+        color={isPositive ? "roiApyPositive" : "roiApyNegative"}
+      />
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/StrategyTotalValue/StrategyTotalValue.stories.tsx
+++ b/src/components/basic/display/StrategyTotalValue/StrategyTotalValue.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Decimal from "decimal.js";
+import { Meta, Story } from "@storybook/react/types-6-0";
+
+import { StrategyTotalValueViewer, Props } from "./viewer";
+
+export default {
+  component: StrategyTotalValueViewer,
+  title: "basic/display/StrategyTotalValue",
+} as Meta;
+
+const Template: Story<Props> = (props) => (
+  <StrategyTotalValueViewer {...props} />
+);
+
+const defaultData: Props = {
+  totalValue: new Decimal("1055987"),
+  holdValue: new Decimal("1055000"),
+  roi: new Decimal("0.0134"),
+  apy: new Decimal("-0.0003"),
+};
+
+export const Default = Template.bind({});
+Default.args = { ...defaultData };
+
+export const NoRoiNorApy = Template.bind({});
+NoRoiNorApy.args = { ...Default.args, roi: undefined, apy: undefined };

--- a/src/components/basic/display/StrategyTotalValue/TotalValue.tsx
+++ b/src/components/basic/display/StrategyTotalValue/TotalValue.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
   margin-bottom: 15px;
 `;
 
-export type Props = { value: Decimal };
+export type Props = { value?: Decimal };
 
 const TOOLTIP =
   "The total value of all your brackets combined in your strategy. This can be compared with the HODL VALUE to compare performance of your strategy vs. if you held the assets without a strategy.";
@@ -29,7 +29,7 @@ export const TotalValue = memo(function TotalValue(props: Props): JSX.Element {
         TOTAL VALUE
       </TextWithTooltip>
       <Text size="xxl" strong>
-        ${formatSmart(value)}
+        {value ? `$${formatSmart(value)}` : "N/A"}
       </Text>
     </Wrapper>
   );

--- a/src/components/basic/display/StrategyTotalValue/TotalValue.tsx
+++ b/src/components/basic/display/StrategyTotalValue/TotalValue.tsx
@@ -1,0 +1,36 @@
+import React, { memo } from "react";
+import Decimal from "decimal.js";
+import styled from "styled-components";
+
+import { formatSmart } from "utils/format";
+
+import { TextWithTooltip } from "components/basic/display/TextWithTooltip";
+import { Text } from "components/basic/display/Text";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  margin-bottom: 15px;
+`;
+
+export type Props = { value: Decimal };
+
+const TOOLTIP =
+  "The total value of all your brackets combined in your strategy. This can be compared with the HODL VALUE to compare performance of your strategy vs. if you held the assets without a strategy.";
+
+export const TotalValue = memo(function TotalValue(props: Props): JSX.Element {
+  const { value } = props;
+
+  return (
+    <Wrapper>
+      <TextWithTooltip color="textGrey" tooltip={TOOLTIP} size="xs">
+        TOTAL VALUE
+      </TextWithTooltip>
+      <Text size="xxl" strong>
+        ${formatSmart(value)}
+      </Text>
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/StrategyTotalValue/index.tsx
+++ b/src/components/basic/display/StrategyTotalValue/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from "react";
+import Decimal from "decimal.js";
 
 import { formatAmountFull } from "@gnosis.pm/dex-js";
 import { Loader } from "@gnosis.pm/safe-react-components";
@@ -51,10 +52,14 @@ export const StrategyTotalValue = memo(function StrategyTotalValue(
     source: "GnosisProtocol",
   });
 
-  const totalValue =
-    baseAmountInUsd &&
-    quoteAmountInUsd &&
-    baseAmountInUsd.add(quoteAmountInUsd);
+  let totalValue: Decimal;
+  if (baseAmountInUsd && quoteAmountInUsd) {
+    totalValue = baseAmountInUsd.add(quoteAmountInUsd);
+  } else if (baseAmountInUsd) {
+    totalValue = baseAmountInUsd;
+  } else {
+    totalValue = quoteAmountInUsd;
+  }
 
   // TODO: calculate hold value
   // TODO: calculate roi

--- a/src/components/basic/display/StrategyTotalValue/index.tsx
+++ b/src/components/basic/display/StrategyTotalValue/index.tsx
@@ -10,6 +10,8 @@ import Strategy from "logic/strategy";
 
 import { StrategyTotalValueViewer } from "./viewer";
 
+// TODO: move to utils?
+
 function addTotals(
   baseAmount: Decimal | null,
   quoteAmount: Decimal | null
@@ -23,6 +25,19 @@ function addTotals(
   } else {
     return undefined;
   }
+}
+
+// TODO: move to utils?
+
+function calculateRoi(
+  current: Decimal | undefined,
+  initial: Decimal | undefined
+): Decimal | undefined {
+  if (!current || !initial) {
+    return undefined;
+  }
+  const difference = current.minus(initial);
+  return difference.div(initial);
 }
 
 export type Props = {
@@ -98,7 +113,6 @@ export const StrategyTotalValue = memo(function StrategyTotalValue(
     source: "GnosisProtocol",
   });
 
-  // TODO: calculate roi
   // TODO: calculate apy
 
   if (
@@ -114,10 +128,13 @@ export const StrategyTotalValue = memo(function StrategyTotalValue(
 
   const holdValue = addTotals(baseDepositAmountInUsd, quoteDepositAmountInUsd);
 
+  const roi = calculateRoi(totalValue, holdValue);
+
   return (
     <StrategyTotalValueViewer
       totalValue={totalValue}
       holdValue={holdValue}
+      roi={roi}
     />
   );
 });

--- a/src/components/basic/display/StrategyTotalValue/index.tsx
+++ b/src/components/basic/display/StrategyTotalValue/index.tsx
@@ -20,8 +20,8 @@ export const StrategyTotalValue = memo(function StrategyTotalValue(
   const {
     baseTokenAddress,
     quoteTokenAddress,
-    baseTokenDetails: { decimals: baseTokenDecimals },
-    quoteTokenDetails: { decimals: quoteTokenDecimals },
+    baseTokenDetails,
+    quoteTokenDetails,
   } = strategy;
 
   const {
@@ -31,7 +31,7 @@ export const StrategyTotalValue = memo(function StrategyTotalValue(
     tokenAddress: baseTokenAddress,
     amount: formatAmountFull({
       amount: strategy.totalBaseBalance(),
-      precision: baseTokenDecimals,
+      precision: baseTokenDetails?.decimals || 18,
       thousandSeparator: false,
       isLocaleAware: false,
     }),
@@ -44,7 +44,7 @@ export const StrategyTotalValue = memo(function StrategyTotalValue(
     tokenAddress: quoteTokenAddress,
     amount: formatAmountFull({
       amount: strategy.totalQuoteBalance(),
-      precision: quoteTokenDecimals,
+      precision: quoteTokenDetails?.decimals || 18,
       thousandSeparator: false,
       isLocaleAware: false,
     }),

--- a/src/components/basic/display/StrategyTotalValue/index.tsx
+++ b/src/components/basic/display/StrategyTotalValue/index.tsx
@@ -1,0 +1,28 @@
+import React, { memo } from "react";
+import Decimal from "decimal.js";
+import { StrategyTotalValueViewer } from "./viewer";
+
+export type Props = {
+  baseAmount: Decimal;
+  baseTokenAddress: string;
+  quoteAmount: Decimal;
+  quoteTokenAddress: string;
+};
+
+export const StrategyTotalValue = memo(function StrategyTotalValue(
+  props: Props
+): JSX.Element {
+  const {
+    baseAmount,
+    baseTokenAddress,
+    quoteAmount,
+    quoteTokenAddress,
+  } = props;
+
+  // TODO: calculate total value
+  // TODO: calculate hold value
+  // TODO: calculate roi
+  // TODO: calculate apy
+
+  return <StrategyTotalValueViewer />;
+});

--- a/src/components/basic/display/StrategyTotalValue/viewer.tsx
+++ b/src/components/basic/display/StrategyTotalValue/viewer.tsx
@@ -12,8 +12,8 @@ const Wrapper = styled.div`
 `;
 
 export type Props = {
-  totalValue: Decimal;
-  holdValue: Decimal;
+  totalValue?: Decimal;
+  holdValue?: Decimal;
   roi?: Decimal;
   apy?: Decimal;
 };

--- a/src/components/basic/display/StrategyTotalValue/viewer.tsx
+++ b/src/components/basic/display/StrategyTotalValue/viewer.tsx
@@ -1,0 +1,32 @@
+import Decimal from "decimal.js";
+import React, { memo } from "react";
+import styled from "styled-components";
+
+import { DetailsTable } from "./DetailsTable";
+import { TotalValue } from "./TotalValue";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 35px;
+`;
+
+export type Props = {
+  totalValue: Decimal;
+  holdValue: Decimal;
+  roi?: Decimal;
+  apy?: Decimal;
+};
+
+export const StrategyTotalValueViewer = memo(function StrategyTotalValueViewer(
+  props: Props
+): JSX.Element {
+  const { totalValue, ...rest } = props;
+
+  return (
+    <Wrapper>
+      <TotalValue value={totalValue} />
+      <DetailsTable {...rest} />
+    </Wrapper>
+  );
+});

--- a/src/components/basic/display/Text/index.tsx
+++ b/src/components/basic/display/Text/index.tsx
@@ -25,10 +25,10 @@ const ReStyledText = styled(SRCText)<Overwrites>`
  * Overwrites Safe React Components <Text/> to introduce on extra size: `xs`
  */
 export const Text = (props: Props): React.ReactElement => {
-  const { children, as, ...rest } = props;
+  const { children, as, size = "md", ...rest } = props;
 
   return (
-    <ReStyledText {...rest} forwardedAs={as}>
+    <ReStyledText {...rest} size={size} forwardedAs={as}>
       {children}
     </ReStyledText>
   );

--- a/src/components/basic/display/TextWithTooltip/index.tsx
+++ b/src/components/basic/display/TextWithTooltip/index.tsx
@@ -1,13 +1,12 @@
 import React, { memo } from "react";
 import styled from "styled-components";
 
-import {
-  ThemeColors,
-  ThemeTextSize,
-} from "@gnosis.pm/safe-react-components/dist/theme";
-import { Text, Icon } from "@gnosis.pm/safe-react-components";
+import { Icon } from "@gnosis.pm/safe-react-components";
+
+import { ThemeColors, ThemeTextSize } from "theme";
 
 import { Tooltip } from "components/basic/display/Tooltip";
+import { Text } from "components/basic/display/Text";
 
 const Wrapper = styled.span`
   display: flex;
@@ -21,13 +20,15 @@ const Wrapper = styled.span`
 
 export interface Props {
   tooltip: string;
-  size: ThemeTextSize;
+  size?: ThemeTextSize;
   color?: ThemeColors;
   className?: string;
   children: React.ReactElement | string;
 }
 
-const component: React.FC<Props> = (props) => {
+export const TextWithTooltip = memo(function TextWithTooltip(
+  props: Props
+): JSX.Element {
   const { children, tooltip, size, color, className } = props;
 
   return (
@@ -40,6 +41,4 @@ const component: React.FC<Props> = (props) => {
       </Tooltip>
     </Wrapper>
   );
-};
-
-export const TextWithTooltip = memo(component);
+});

--- a/src/components/basic/display/TokenDisplay/index.tsx
+++ b/src/components/basic/display/TokenDisplay/index.tsx
@@ -4,13 +4,13 @@ import { Loader } from "@gnosis.pm/safe-react-components";
 
 import { useTokenDetails } from "hooks/useTokenDetails";
 
-import { ThemeColors, ThemeTextSize } from "theme";
+import { ThemeColors, ThemeLoaderSize } from "theme";
 
 import { Text } from "components/basic/display/Text";
 
 export interface Props {
   token: string;
-  size?: ThemeTextSize;
+  size?: ThemeLoaderSize;
   color?: ThemeColors;
   className?: string;
 }
@@ -36,7 +36,7 @@ export const TokenDisplay = memo(function TokenDisplay(
       {tokenDetails.symbol}
     </Text>
   ) : isLoading ? (
-    <Loader size={size === "xl" ? "lg" : size} className={className} />
+    <Loader size={size} className={className} />
   ) : (
     <Text size={size} color={color} strong as="span" className={className}>
       -

--- a/src/components/pages/strategies/Active/StrategyTab.tsx
+++ b/src/components/pages/strategies/Active/StrategyTab.tsx
@@ -16,6 +16,7 @@ import {
   BracketRowData,
   BracketsTable,
 } from "components/basic/display/BracketsTable";
+import { StrategyTotalValue } from "components/basic/display/StrategyTotalValue";
 
 export type Props = {
   strategy: Strategy;
@@ -146,7 +147,7 @@ export const StrategyTab = memo(function StrategyTab(
           type="left"
           brackets={leftBrackets}
         />
-        <div style={{ justifySelf: "center" }}>TODO</div>
+        <StrategyTotalValue strategy={strategy} />
         <BracketsTable
           baseTokenAddress={baseTokenAddress}
           quoteTokenAddress={quoteTokenAddress}

--- a/src/logic/strategy.ts
+++ b/src/logic/strategy.ts
@@ -344,6 +344,38 @@ class Strategy {
       ZERO
     );
   }
+
+  public totalDeposits(): {
+    baseTokenDeposits: BN;
+    quoteTokenDeposits: BN;
+  } {
+    const [baseTokenDeposits, quoteTokenDeposits] = this.brackets.reduce<
+      [BN, BN]
+    >(
+      ([totalBaseBalance, totalQuoteBalance], bracket) => {
+        const [baseBalance, quoteBalance] = bracket.deposits.reduce<[BN, BN]>(
+          ([baseBracketBalance, quoteBracketBalance], deposit) => {
+            const bnAmount = new BN(deposit.amount);
+
+            if (deposit.token === this.baseTokenAddress) {
+              return [baseBracketBalance.add(bnAmount), quoteBracketBalance];
+            } else {
+              return [baseBracketBalance, quoteBracketBalance.add(bnAmount)];
+            }
+          },
+          [ZERO, ZERO]
+        );
+
+        return [
+          totalBaseBalance.add(baseBalance),
+          totalQuoteBalance.add(quoteBalance),
+        ];
+      },
+      [ZERO, ZERO]
+    );
+
+    return { baseTokenDeposits, quoteTokenDeposits };
+  }
 }
 
 export default Strategy;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,24 +20,32 @@ const newColors = {
 
   // text
   textGrey: "#5D6D74",
+
+  // roi/apy
+  roiApyPositive: "#008D73",
+  roiApyNegative: "#F42117",
 };
 
-const xsTextSize = {
+const newTextSizes = {
   xs: {
     fontSize: "10px",
     lineHeight: "14px",
+  },
+  xxl: {
+    fontSize: "26px",
+    lineHeight: "36px",
   },
 };
 
 export interface Theme extends themeType {
   colors: colorsType & typeof newColors;
-  text: textType & { size: typeof xsTextSize };
+  text: textType & { size: typeof newTextSizes };
 }
 
 export const theme: Theme = {
   ...srcTheme,
   colors: { ...srcTheme.colors, ...newColors },
-  text: { ...srcTheme.text, size: { ...srcTheme.text.size, ...xsTextSize } },
+  text: { ...srcTheme.text, size: { ...srcTheme.text.size, ...newTextSizes } },
 };
 
 export type ThemeTextSize = keyof typeof theme["text"]["size"];

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -49,4 +49,5 @@ export const theme: Theme = {
 };
 
 export type ThemeTextSize = keyof typeof theme["text"]["size"];
+export type ThemeLoaderSize = keyof typeof theme["loader"]["size"];
 export type ThemeColors = keyof typeof theme["colors"];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -28,6 +28,7 @@ export const DEFAULT_INPUT_WIDTH = "130px";
 export const ZERO_DECIMAL = new Decimal("0");
 export const ONE_DECIMAL = new Decimal("1");
 export const TEN_DECIMAL = new Decimal("10");
+export const ONE_HUNDRED_DECIMAL = new Decimal("100");
 
 export const MINIMUM_BRACKETS = 1;
 export const MAXIMUM_BRACKETS = 10;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -5,8 +5,6 @@ import { formatSmart as dexJsFormatSmart } from "@gnosis.pm/dex-js";
 
 import { TEN_DECIMAL } from "utils/constants";
 
-const EXPAND_PRECISION_BY = 20;
-
 // TODO: consider moving to dex-js
 /**
  * Formats given amount nicely.
@@ -34,9 +32,14 @@ export function formatSmart(amount: Decimal | string, precision = 0): string {
 
   console.log("amount to format", amountDecimal.toFixed());
 
+  const decimalPlaces = amountDecimal.decimalPlaces();
+
   const amountBN = new BN(
-    amountDecimal.mul(TEN_DECIMAL.pow(EXPAND_PRECISION_BY)).toFixed()
+    amountDecimal
+      .mul(TEN_DECIMAL.pow(decimalPlaces))
+      .toDecimalPlaces(0)
+      .toFixed()
   );
 
-  return dexJsFormatSmart(amountBN, EXPAND_PRECISION_BY + precision);
+  return dexJsFormatSmart(amountBN, decimalPlaces + precision);
 }


### PR DESCRIPTION
~# :warning: Depends on https://github.com/gnosis/safe-cmm-app-react/pull/144~
~Do NOT merge before that one~

# Description

Implementing Total value component of the active strategies page fold out.
![screenshot_2020-11-09_14-34-55](https://user-images.githubusercontent.com/43217/98604524-abf0f200-2298-11eb-9a8d-52c723ba3de0.png)



# To Test

## App

1. Make sure there's at least one active strategy deployed
1. Head to strategy page
1. Expand one strategy 

- [ ] Total amount should be populated
- [ ] Hodl value should be populated
- [ ] Roi value should be populated
- [ ] Apy value currently set to `N/A`

## Storybook
1. Visit storybook endpoint
1. Select `Strategy Total Value`

- [ ] Component should match design
- [ ] You should see how the component looks with all the fields filled in

# Background

- ~Only Total value implemented.~ Missing ~`hodl`, `roi` and~ `apy`

