### PR TITLE
Highlight brackets on hover

### DIFF
--- a/src/components/basic/display/BracketsTable/Table.tsx
+++ b/src/components/basic/display/BracketsTable/Table.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useCallback } from "react";
 
 import {
   Table as MUITable,
@@ -17,7 +17,7 @@ import { formatSmart } from "utils/format";
 
 import { TokenDisplay } from "components/basic/display/TokenDisplay";
 
-import { BracketRowData } from ".";
+import { Props as ParentProps } from ".";
 
 const StyledTable = withStyles({
   root: { borderCollapse: "separate", borderSpacing: "0 2px" },
@@ -82,14 +82,17 @@ const StyledRow = withStyles({
   },
 })(TableRow);
 
-export type Props = {
-  baseTokenAddress: string;
-  quoteTokenAddress: string;
-  brackets: BracketRowData[];
-} & RowProps;
+export type Props = ParentProps & RowProps;
 
 export const Table = memo(function Table(props: Props): JSX.Element {
-  const { baseTokenAddress, quoteTokenAddress, brackets, type } = props;
+  const {
+    baseTokenAddress,
+    quoteTokenAddress,
+    brackets,
+    type,
+    hoverId,
+    onHover,
+  } = props;
 
   // Token components are repeated often, reusing same instance
   const priceTokenDisplay = (
@@ -110,6 +113,8 @@ export const Table = memo(function Table(props: Props): JSX.Element {
     [ZERO_DECIMAL, ZERO_DECIMAL]
   );
 
+  const onMouseLeave = useCallback((): void => onHover && onHover(), [onHover]);
+
   return (
     <StyledTable>
       <TableHead>
@@ -122,7 +127,13 @@ export const Table = memo(function Table(props: Props): JSX.Element {
       </TableHead>
       <TableBody>
         {brackets.map((bracket, id) => (
-          <StyledRow key={id} type={type}>
+          <StyledRow
+            key={id}
+            type={type}
+            onMouseEnter={() => onHover && onHover(id)}
+            onMouseLeave={onMouseLeave}
+            hover={hoverId === id}
+          >
             <StyledCell grey>
               {formatSmart(bracket.lowPrice)} {priceTokenDisplay} <br />
               {formatSmart(bracket.highPrice)} {priceTokenDisplay}

--- a/src/components/basic/display/BracketsTable/index.tsx
+++ b/src/components/basic/display/BracketsTable/index.tsx
@@ -20,6 +20,8 @@ export type Props = {
   quoteTokenAddress: string;
   brackets: BracketRowData[];
   type: "left" | "right";
+  hoverId?: number;
+  onHover?: (bracketId?: number) => void;
 };
 
 export const BracketsTable = memo(function BracketsTable(

--- a/src/components/basic/display/BracketsView/Brackets.tsx
+++ b/src/components/basic/display/BracketsView/Brackets.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useContext } from "react";
+import React, { memo, useCallback, useContext } from "react";
 import styled from "styled-components";
 import { range } from "lodash";
 
@@ -35,7 +35,7 @@ const Wrapper = styled.div<{ hasLeftBrackets?: boolean; isDeploy?: boolean }>`
       isDeploy
         ? ""
         : `
-          &:hover {
+          &.hover,&:hover {
             background-color: ${theme.colors.borderLightGreen};
           }`}
   }
@@ -64,7 +64,8 @@ const Wrapper = styled.div<{ hasLeftBrackets?: boolean; isDeploy?: boolean }>`
       isDeploy
         ? ""
         : `
-          &:hover {
+          
+          &.hover,&:hover {
             background-color: ${theme.colors.borderLightPurple};
           }`}
   }
@@ -75,19 +76,36 @@ const Wrapper = styled.div<{ hasLeftBrackets?: boolean; isDeploy?: boolean }>`
 `;
 
 export const Brackets = memo(function Brackets(): JSX.Element {
-  const { totalBrackets, leftBrackets, rightBrackets, type } = useContext(
-    BracketsViewContext
-  );
+  const {
+    totalBrackets,
+    leftBrackets,
+    rightBrackets,
+    type,
+    hoverId,
+    onHover,
+  } = useContext(BracketsViewContext);
+
+  const onMouseLeave = useCallback((): void => onHover && onHover(), [onHover]);
 
   return (
     <Wrapper hasLeftBrackets={!!leftBrackets} isDeploy={type === "deploy"}>
       {range(
         !leftBrackets && !rightBrackets ? totalBrackets : leftBrackets
       ).map((id) => (
-        <div className="left" key={id} />
+        <div
+          className={`left ${hoverId === id ? "hover" : ""}`}
+          key={id}
+          onMouseEnter={() => onHover && onHover(id)}
+          onMouseLeave={onMouseLeave}
+        />
       ))}
-      {range(rightBrackets).map((id) => (
-        <div className="right" key={id + leftBrackets} />
+      {range(leftBrackets, rightBrackets + leftBrackets).map((id) => (
+        <div
+          className={`right ${hoverId === id ? "hover" : ""}`}
+          key={id}
+          onMouseEnter={() => onHover && onHover(id)}
+          onMouseLeave={onMouseLeave}
+        />
       ))}
     </Wrapper>
   );

--- a/src/components/basic/display/BracketsView/viewer.tsx
+++ b/src/components/basic/display/BracketsView/viewer.tsx
@@ -31,6 +31,9 @@ export type Props = {
   lowestPrice?: string;
   startPrice?: string;
   highestPrice?: string;
+
+  hoverId?: number;
+  onHover?: (bracketId?: number) => void;
 };
 
 type ExtraContextProps = {

--- a/src/components/pages/strategies/Active/ActiveTable.tsx
+++ b/src/components/pages/strategies/Active/ActiveTable.tsx
@@ -119,7 +119,7 @@ export const ActiveTable = memo(function ActiveTable({
                   )}
                 </TableCell>
                 <TableCell>
-                  <IconButton onClick={makeStrategyFoldoutHandler(strategy)}>
+                  <IconButton>
                     {strategy.transactionHash === foldOutStrategy ? (
                       <ChevronUp />
                     ) : (

--- a/src/components/pages/strategies/Active/ActiveTable.tsx
+++ b/src/components/pages/strategies/Active/ActiveTable.tsx
@@ -119,7 +119,7 @@ export const ActiveTable = memo(function ActiveTable({
                   )}
                 </TableCell>
                 <TableCell>
-                  <IconButton>
+                  <IconButton onClick={makeStrategyFoldoutHandler(strategy)}>
                     {strategy.transactionHash === foldOutStrategy ? (
                       <ChevronUp />
                     ) : (

--- a/src/components/pages/strategies/Active/StrategyTab.tsx
+++ b/src/components/pages/strategies/Active/StrategyTab.tsx
@@ -4,7 +4,7 @@ import Decimal from "decimal.js";
 
 import { useGetPrice } from "hooks/useGetPrice";
 
-import { ZERO_DECIMAL } from "utils/constants";
+import { ZERO_DECIMAL, TEN_DECIMAL } from "utils/constants";
 import { calculateBracketsFromMarketPrice } from "utils/calculateBrackets";
 
 import { StrategyState } from "types";
@@ -27,9 +27,6 @@ const Grid = styled.div`
   grid-template-columns: repeat(3, 1fr);
   align-items: baseline;
 `;
-
-// TODO: move to constants
-const TEN_DECIMAL = new Decimal("10");
 
 // TODO: move to utils
 function calculatePriceFromPartial(
@@ -74,18 +71,28 @@ function formatBrackets(strategy: StrategyState): BracketRowData[] {
 export const StrategyTab = memo(function StrategyTab(
   props: Props
 ): JSX.Element {
-  const [hoverBracketId, setHoverBracketId] = useState<number | undefined>(
-    undefined
-  );
-
   const { strategy } = props;
-  const { baseToken, quoteToken, brackets, priceRange } = strategy;
+  const { baseToken, quoteToken } = strategy;
 
   const { price } = useGetPrice({
     source: "GnosisProtocol",
     baseToken,
     quoteToken,
   });
+
+  // Split component in 2 to avoid re-fetching the price when hovering over brackets
+  return <StrategyTabView price={price} {...props} />;
+});
+
+const StrategyTabView = memo(function StrategyTabView(
+  props: Props & { price?: Decimal | null }
+): JSX.Element {
+  const [hoverBracketId, setHoverBracketId] = useState<number | undefined>(
+    undefined
+  );
+
+  const { strategy, price } = props;
+  const { baseToken, quoteToken, brackets, priceRange } = strategy;
 
   const { baseTokenBrackets, quoteTokenBrackets } = useMemo(
     () =>

--- a/src/components/pages/strategies/Active/StrategyTab.tsx
+++ b/src/components/pages/strategies/Active/StrategyTab.tsx
@@ -1,8 +1,6 @@
-import React, { memo, useMemo } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
 import Decimal from "decimal.js";
-
-import { formatAmountFull } from "@gnosis.pm/dex-js";
 
 import { useGetPrice } from "hooks/useGetPrice";
 
@@ -76,6 +74,10 @@ function formatBrackets(strategy: StrategyState): BracketRowData[] {
 export const StrategyTab = memo(function StrategyTab(
   props: Props
 ): JSX.Element {
+  const [hoverBracketId, setHoverBracketId] = useState<number | undefined>(
+    undefined
+  );
+
   const { strategy } = props;
   const { baseToken, quoteToken, brackets, priceRange } = strategy;
 
@@ -105,6 +107,14 @@ export const StrategyTab = memo(function StrategyTab(
     return { leftBrackets, rightBrackets };
   }, [baseTokenBrackets, strategy]);
 
+  const rightBracketsOnHover = useCallback(
+    (bracketId?: number) =>
+      setHoverBracketId(
+        bracketId !== undefined && bracketId + leftBrackets.length
+      ),
+    [leftBrackets.length]
+  );
+
   return (
     <Wrapper>
       <BracketsViewer
@@ -117,6 +127,8 @@ export const StrategyTab = memo(function StrategyTab(
         leftBrackets={baseTokenBrackets}
         rightBrackets={quoteTokenBrackets}
         startPrice={price?.isFinite() ? price.toString() : "N/A"}
+        hoverId={hoverBracketId}
+        onHover={setHoverBracketId}
       />
       <Grid>
         <BracketsTable
@@ -124,6 +136,8 @@ export const StrategyTab = memo(function StrategyTab(
           quoteTokenAddress={quoteToken.address}
           type="left"
           brackets={leftBrackets}
+          hoverId={hoverBracketId}
+          onHover={setHoverBracketId}
         />
         <StrategyTotalValue strategy={strategy} />
         <BracketsTable
@@ -131,6 +145,10 @@ export const StrategyTab = memo(function StrategyTab(
           quoteTokenAddress={quoteToken.address}
           type="right"
           brackets={rightBrackets}
+          hoverId={
+            hoverBracketId !== undefined && hoverBracketId - leftBrackets.length
+          }
+          onHover={rightBracketsOnHover}
         />
       </Grid>
     </Wrapper>


### PR DESCRIPTION
# Description

Highlighting brackets on hover

(A gif would be better but that's what I got)
![screenshot_2020-11-19_09-34-31](https://user-images.githubusercontent.com/43217/99702211-611a6b80-2a4a-11eb-9362-9acd1eb1058d.png)

Missing part of https://github.com/gnosis/safe-cmm-app-react/issues/94

# To Test
1. On an active strategy, hover over a bracket

- [ ] Corresponding bracket on the table should be highlighted
- [ ] The reverse should be true: hovering over a table row highlights a bracket

# Background

N/A

