### PR TITLE
Fixed click on dropdown arrow

### DIFF
--- a/src/components/pages/strategies/Active/ActiveTable.tsx
+++ b/src/components/pages/strategies/Active/ActiveTable.tsx
@@ -115,7 +115,7 @@ export const ActiveTable = memo(function ActiveTable({
                   )}
                 </TableCell>
                 <TableCell>
-                  <IconButton onClick={makeStrategyFoldoutHandler(strategy)}>
+                  <IconButton>
                     {strategy.transactionHash === foldOutStrategy ? (
                       <ChevronUp />
                     ) : (


### PR DESCRIPTION
# Description

Fixing a bug

# To Test
1. On active strategies tab
1. Click on the dropdown arrow
![screenshot_2020-11-23_13-10-10](https://user-images.githubusercontent.com/43217/100015622-20de2480-2d8d-11eb-9eb1-f5f5312c806e.png)

- [x] Strategy should expand/retract as requested

# Background

Turns out we do need to remove the handler from the button.
If not, the action is registered twice: once because of the button and another time because of the row.

