### PR TITLE
Task: Miscellaneous fixes (version overlapping strategies, counter/displays)

### DIFF
--- a/src/components/TabView.tsx
+++ b/src/components/TabView.tsx
@@ -7,19 +7,15 @@ import Deploy from "routes/Deploy";
 import { Route, Switch, Redirect, useHistory } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 
-import {
-  strategyCountByStatus,
-  totalStrategyCount,
-} from "state/selectors/strategyCounter";
+import { strategyCountByStatus } from "state/selectors/strategyCounter";
 import { SafeStyleTabHeaderWithCounter } from "./navigation/tabs/SafeStyleTabHeaderWithCounter";
-import { Badge } from "./basic/display/Badge";
 
 const DEFAULT_TAB = "deployment";
 
 export const TabView = memo(function TabView(): JSX.Element {
   const history = useHistory();
 
-  const strategyCount = useRecoilValue(totalStrategyCount);
+  const strategyCount = useRecoilValue(strategyCountByStatus("ACTIVE"));
 
   const [selectedTab, setSelectedTab] = useState(DEFAULT_TAB);
   const handleChangeTab = useCallback(

--- a/src/components/Version.tsx
+++ b/src/components/Version.tsx
@@ -3,8 +3,8 @@ import styled from "styled-components";
 
 const HiddenBox = styled.div`
   color: white;
-  position: absolute;
-  bottom: 0;
+  position: fixed;
+  top: 0;
   right: 0;
 `;
 

--- a/src/components/pages/strategies/Closed/index.tsx
+++ b/src/components/pages/strategies/Closed/index.tsx
@@ -9,7 +9,9 @@ import { strategiesOfStatusSelector } from "state/selectors/strategiesOfStatus";
 import { strategiesLoadingState } from "state/atoms";
 
 export const Closed = memo(function Closed(): JSX.Element {
-  const strategies = useRecoilValue(strategiesOfStatusSelector("CLOSED"));
+  const strategies = useRecoilValue(
+    strategiesOfStatusSelector(["CLOSED", "TRADING_STOPPED"])
+  );
   const strategyLoadingState = useRecoilValue(strategiesLoadingState);
 
   if (strategyLoadingState === "LOADING" && strategies.length === 0) {

--- a/src/state/selectors/strategiesOfStatus.ts
+++ b/src/state/selectors/strategiesOfStatus.ts
@@ -1,5 +1,6 @@
+import { sortBy } from "lodash";
 import { selectorFamily } from "recoil";
-import { StrategyStatusEnum } from "types";
+import { StrategyState, StrategyStatusEnum } from "types";
 import { strategiesByStatusSelector } from "./strategiesByStatus";
 
 /**
@@ -7,6 +8,24 @@ import { strategiesByStatusSelector } from "./strategiesByStatus";
  */
 export const strategiesOfStatusSelector = selectorFamily({
   key: "strategiesOfStatusSelector",
-  get: (status: StrategyStatusEnum) => ({ get }) =>
-    get(strategiesByStatusSelector)[status] || [],
+  get: (statusOrStatuses: StrategyStatusEnum | StrategyStatusEnum[]) => ({
+    get,
+  }) => {
+    let strategies = [];
+    if (Array.isArray(statusOrStatuses)) {
+      (statusOrStatuses as StrategyStatusEnum[]).forEach((status) => {
+        strategies = [
+          ...strategies,
+          ...(get(strategiesByStatusSelector)[status] || []),
+        ];
+      });
+    } else {
+      strategies = get(strategiesByStatusSelector)[statusOrStatuses] || [];
+    }
+
+    // Sort by creation date
+    return sortBy(strategies, (o: StrategyState): number => {
+      return o.created.valueOf();
+    }).reverse();
+  },
 });


### PR DESCRIPTION
# Description

This PR fixes the verison overlapping the strategies. It is now located in the top-right corner of the app:
![image](https://user-images.githubusercontent.com/969493/100102156-7d137800-2e63-11eb-97a9-07f7a412bb10.png)

It also updates the counters/selectors in various ways:
- The "Strategies" Tab now only counts the active strategies
- The "Closed" Tab now counts and displays "Closed" + "Trading Stopped" Strategies
- Strategies are now always sorted in descending order.


# To Test
- [x] Version info top right (difficult to select sometimes)
- [x] Strategy count matches active count
- [x] Closed Tab counter matches amount displayed in tab

# Background
/