### PR TITLE
Feature/#154/x dai gp prices

### DIFF
--- a/src/api/prices.ts
+++ b/src/api/prices.ts
@@ -27,12 +27,6 @@ function buildCacheKey(
 ): string {
   const parts = [source, baseToken.address, quoteToken.address];
 
-  if (source === "GnosisProtocol") {
-    // GP prices use average of both sides to account for potentially high spreads
-    // Thus, sorting parts make the key the same doesn't matter the token order
-    parts.sort();
-  }
-
   const options = sourceOptions
     ? Object.keys(sourceOptions)
         .sort()

--- a/src/hooks/useGetPrice.ts
+++ b/src/hooks/useGetPrice.ts
@@ -55,18 +55,7 @@ export function useGetPrice(params: Params): Result {
       }
       setIsLoading(false);
 
-      // TODO: maybe unnecessary
-      setPrice((curr) => {
-        console.log(
-          `is price different? does this change anything?`,
-          curr?.toString(),
-          newPrice?.toString()
-        );
-        if (curr && newPrice && curr.eq(newPrice)) {
-          return curr;
-        }
-        return newPrice;
-      });
+      setPrice(newPrice);
     }
 
     updatePrice();


### PR DESCRIPTION
# Description

Closes #154 

All xDai price queries now will go against Gnosis Protocol instead of 1inch

Also fixed a bug with GP price caching

# To Test
1. On xDai safe, open the app
1. Select any 2 tokens from the dropdown

- [ ] A price should be displayed

1. Invert the tokens

- [ ] A different (inverse) price should be displayed

# Background

N/A

