### PR TITLE
Make pending and closed table rows clickable

### DIFF
--- a/src/components/pages/strategies/Closed/ClosedTable.tsx
+++ b/src/components/pages/strategies/Closed/ClosedTable.tsx
@@ -92,7 +92,11 @@ export const ClosedTable = memo(function ClosedTable({
         <TableBody>
           {strategies.map((strategy) => (
             <>
-              <TableRow key={strategy.transactionHash}>
+              <TableRow
+                key={strategy.transactionHash}
+                hover
+                onClick={makeStrategyFoldoutHandler(strategy)}
+              >
                 <TableCell>{strategy.created.toLocaleString()}</TableCell>
                 <TableCell>
                   {strategy.quoteToken && strategy.baseToken
@@ -115,7 +119,7 @@ export const ClosedTable = memo(function ClosedTable({
                 </TableCell>
                 <TableCell>{/* status message */}</TableCell>
                 <TableCell>
-                  <IconButton onClick={makeStrategyFoldoutHandler(strategy)}>
+                  <IconButton>
                     {strategy.transactionHash === foldOutStrategy ? (
                       <ChevronUp />
                     ) : (

--- a/src/components/pages/strategies/Pending/PendingTable.tsx
+++ b/src/components/pages/strategies/Pending/PendingTable.tsx
@@ -77,7 +77,11 @@ export const PendingTable = memo(function PendingTable({
         <TableBody>
           {strategies.map((strategy) => (
             <>
-              <TableRow key={strategy.transactionHash}>
+              <TableRow
+                key={strategy.transactionHash}
+                hover
+                onClick={makeStrategyFoldoutHandler(strategy)}
+              >
                 <TableCell>{strategy.created.toLocaleString()}</TableCell>
                 <TableCell>
                   {strategy.quoteToken && strategy.baseToken
@@ -100,7 +104,7 @@ export const PendingTable = memo(function PendingTable({
                 </TableCell>
                 <TableCell>{/* status message */}</TableCell>
                 <TableCell>
-                  <IconButton onClick={makeStrategyFoldoutHandler(strategy)}>
+                  <IconButton>
                     {strategy.transactionHash === foldOutStrategy ? (
                       <ChevronUp />
                     ) : (


### PR DESCRIPTION
# Description

Small UI change, making both pending and closed table rows clickable, like active table.

# To Test
1. Make sure there's a pending and a closed strategy
2. On pending, hover over the row

- [ ] The row should be highlighted

3. Click on the row

- [ ] It should expand

4. On closed tab, repeat steps 2 and 3. Expect the same result.

# Background

N/A

