### PR TITLE
Fix xDai withdrawal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-app-gnosis-protocol",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1150,17 +1150,17 @@
       },
       "dependencies": {
         "@babel/helper-module-imports": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
-          "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+          "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
           "requires": {
-            "@babel/types": "^7.12.1"
+            "@babel/types": "^7.12.5"
           }
         },
         "@babel/types": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
-          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+          "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -1596,6 +1596,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@chainlink/contracts-0.0.10": {
+      "version": "npm:@chainlink/contracts@0.0.10",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+      "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+      "requires": {
+        "@truffle/contract": "^4.2.6",
+        "ethers": "^4.0.45"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1948,17 +1957,17 @@
       }
     },
     "@gnosis.pm/dex-liquidity-provision": {
-      "version": "github:gnosis/dex-liquidity-provision#ffb9e5f112f2099a1c6e87f1e32fff456c50270c",
-      "from": "github:gnosis/dex-liquidity-provision#fix/add-withdraw-helper-to-wrapper",
+      "version": "github:gnosis/dex-liquidity-provision#8ec9ba3c7a9b17ec743b7e983ff8a0b46d2d509d",
+      "from": "github:gnosis/dex-liquidity-provision#8ec9ba3c7a9b17ec743b7e983ff8a0b46d2d509d",
       "requires": {
-        "@gnosis.pm/dex-contracts": "^0.4.2",
-        "@gnosis.pm/owl-token": "^3.1.0",
-        "@gnosis.pm/safe-contracts": "v1.1.1-dev.2",
+        "@gnosis.pm/dex-contracts": "^0.5.0",
+        "@gnosis.pm/owl-token": "^4.0.0",
+        "@gnosis.pm/safe-contracts": "v1.2.0",
         "@gnosis.pm/solidity-data-structures": "=1.2.4",
-        "@gnosis.pm/util-contracts": "^2.0.6",
+        "@gnosis.pm/util-contracts": "^2.0.7",
         "@openzeppelin/contracts": "=2.5.1",
-        "@truffle/contract": "4.2.22",
-        "axios": "^0.20.0",
+        "@truffle/contract": "4.2.27",
+        "axios": "^0.21.0",
         "bignumber.js": "^9.0.0",
         "bn.js": "^5.1.2",
         "canonical-weth": "^1.4.0",
@@ -1968,134 +1977,41 @@
         "eth-gas-reporter": "^0.2.17",
         "ethereumjs-util": "^7.0.4",
         "node-fetch": "^2.6.0",
-        "synthetix-js": "=2.27.4",
+        "synthetix-js": "=2.30.1",
         "truffle": "^5.1.39",
         "truffle-hdwallet-provider": "^1.0.0-web3one.1",
         "typescript-logging": "^1.0.0"
       },
       "dependencies": {
-        "@chainlink/contracts-0.0.9": {
-          "version": "npm:@chainlink/contracts@0.0.9",
-          "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.9.tgz",
-          "integrity": "sha512-bI97GItkgoViPNhJT9EDf/i33gMwpQj4MywV6IqMStKCoPrUkrTpx6Tt0Knhf73U8zh4qcY2+hoQ9Yqr8gLUqg==",
-          "requires": {
-            "@truffle/contract": "^4.2.6",
-            "ethers": "^4.0.45"
-          }
-        },
         "@gnosis.pm/dex-contracts": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/@gnosis.pm/dex-contracts/-/dex-contracts-0.4.3.tgz",
-          "integrity": "sha512-ObyItfEzWRwfwWSSncPFP8aT54+Vi7VzTvqCbNYTwF+Einn9kdJvasTWkFaw5eiZE1ykD//kFB4T8xv80F2lBw==",
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@gnosis.pm/dex-contracts/-/dex-contracts-0.5.0.tgz",
+          "integrity": "sha512-b3MgplVbd+6D3u9O0dVNU65ZYrD/FxSBv+X52ILHq9fTAMh5zGNfkUIYEJtc7QTrULhnmEUZJ3DO7sGh+SPReA==",
           "requires": {
             "bn.js": "^5.1.3"
           }
         },
-        "@gnosis.pm/owl-token": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@gnosis.pm/owl-token/-/owl-token-3.2.1.tgz",
-          "integrity": "sha512-qS8PopmQRpkQEy5+nGqQ2QVJnJDXubgWfubqvrcr5tVdpyXhMd0QYv+t8nzwYq3at1pxa6VMeucuki+KVfPJUQ==",
-          "requires": {
-            "@gnosis.pm/gno-token": "^2.0.0",
-            "@gnosis.pm/util-contracts": "^2.0.0",
-            "verify-on-etherscan": "^1.1.1"
-          }
-        },
-        "@gnosis.pm/safe-contracts": {
-          "version": "1.1.1-dev.2",
-          "resolved": "https://registry.npmjs.org/@gnosis.pm/safe-contracts/-/safe-contracts-1.1.1-dev.2.tgz",
-          "integrity": "sha512-x0x8K3/XzfDmtmL6RaF8eSJUPJVmT7jd29kmwoodm/JlYlyOmdQNBynUZUTkmknIlF1coiypCLls9zDbx8QQfw==",
-          "requires": {
-            "@truffle/hdwallet-provider": "^1.0.0",
-            "dotenv": "^8.0.0",
-            "openzeppelin-solidity": "^2.0.0",
-            "shelljs": "^0.8.3",
-            "solc": "0.5.14",
-            "truffle": "^5.1.21"
-          }
-        },
-        "@truffle/codec": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.7.1.tgz",
-          "integrity": "sha512-mNd6KnW6J0UB1zafGBXDlTEbCMvWpmPAJmzv7aF/nAIaN/F8UePSCiQ1OTQP39Rprj6GFiCCaWVnBAwum6UGSg==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "bn.js": "^4.11.8",
-            "borc": "^2.1.2",
-            "debug": "^4.1.0",
-            "lodash.clonedeep": "^4.5.0",
-            "lodash.escaperegexp": "^4.1.2",
-            "lodash.partition": "^4.6.0",
-            "lodash.sum": "^4.0.2",
-            "semver": "^6.3.0",
-            "source-map-support": "^0.5.19",
-            "utf8": "^3.0.0",
-            "web3-utils": "1.2.9"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.9",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            },
-            "web3-utils": {
-              "version": "1.2.9",
-              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-              "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
-              "requires": {
-                "bn.js": "4.11.8",
-                "eth-lib": "0.2.7",
-                "ethereum-bloom-filters": "^1.0.6",
-                "ethjs-unit": "0.1.6",
-                "number-to-bn": "1.7.0",
-                "randombytes": "^2.1.0",
-                "underscore": "1.9.1",
-                "utf8": "3.0.0"
-              },
-              "dependencies": {
-                "bn.js": {
-                  "version": "4.11.8",
-                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                  "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-                }
-              }
-            }
-          }
-        },
         "@truffle/contract": {
-          "version": "4.2.22",
-          "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.22.tgz",
-          "integrity": "sha512-mkkuQucuZb+kHlnDwcEF5CXKa7c3hZRTN7y0NSVGlNKPMAd+VMoGi4RsJy3o0ALAumsxi714sGMHJagqoz/RmA==",
+          "version": "4.2.27",
+          "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.27.tgz",
+          "integrity": "sha512-3IVUmYYrYopY+9rdOK3EZgRB1NnC+NI83FQ2Xuvgx4fg92Y/ggcofCJdI+D/iXRwaMFkIkqgJ7K8qZEJsoHWjg==",
           "requires": {
             "@truffle/blockchain-utils": "^0.0.25",
-            "@truffle/contract-schema": "^3.2.5",
-            "@truffle/debug-utils": "^4.2.8",
+            "@truffle/contract-schema": "^3.3.1",
+            "@truffle/debug-utils": "^4.2.13",
             "@truffle/error": "^0.0.11",
-            "@truffle/interface-adapter": "^0.4.16",
+            "@truffle/interface-adapter": "^0.4.18",
             "bignumber.js": "^7.2.1",
             "ethereum-ens": "^0.8.0",
             "ethers": "^4.0.0-beta.1",
             "source-map-support": "^0.5.19",
-            "web3": "1.2.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-promievent": "1.2.1",
-            "web3-eth-abi": "1.2.1",
-            "web3-utils": "1.2.1"
+            "web3": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-utils": "1.2.9"
           },
           "dependencies": {
-            "@truffle/blockchain-utils": {
-              "version": "0.0.25",
-              "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz",
-              "integrity": "sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==",
-              "requires": {
-                "source-map-support": "^0.5.19"
-              }
-            },
             "bignumber.js": {
               "version": "7.2.1",
               "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
@@ -2103,97 +2019,15 @@
             }
           }
         },
-        "@truffle/contract-schema": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.3.1.tgz",
-          "integrity": "sha512-xGBiYiCCW8hKuD/G8xb9w0WUuhdJDmQuz18A2Ens3Y8MO+jWA+Zw7xxZjCtiXAu9440Fj2V/BCXWcV6RxGKgBQ==",
-          "requires": {
-            "ajv": "^6.10.0",
-            "crypto-js": "^3.1.9-1",
-            "debug": "^4.1.0"
-          }
-        },
-        "@truffle/debug-utils": {
-          "version": "4.2.14",
-          "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.2.14.tgz",
-          "integrity": "sha512-g5UTX2DPTzrjRjBJkviGI2IrQRTTSvqjmNWCNZNXP+vgQKNxL9maLZhQ6oA3BuuByVW/kusgYeXt8+W1zynC8g==",
-          "requires": {
-            "@truffle/codec": "^0.7.1",
-            "@trufflesuite/chromafi": "^2.2.1",
-            "chalk": "^2.4.2",
-            "debug": "^4.1.0",
-            "highlight.js": "^9.15.8",
-            "highlightjs-solidity": "^1.0.18"
-          }
-        },
         "@truffle/error": {
           "version": "0.0.11",
           "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.11.tgz",
           "integrity": "sha512-ju6TucjlJkfYMmdraYY/IBJaFb+Sa+huhYtOoyOJ+G29KcgytUVnDzKGwC7Kgk6IsxQMm62Mc1E0GZzFbGGipw=="
         },
-        "@trufflesuite/chromafi": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/@trufflesuite/chromafi/-/chromafi-2.2.1.tgz",
-          "integrity": "sha512-kODhM/LsjPrSRGQdaHe113v4xob/aheRmdwN0i6seVNavmHGBvC4ob3COlD1GjaklXsl9QWw4fengowIx1+07Q==",
-          "requires": {
-            "ansi-mark": "^1.0.0",
-            "ansi-regex": "^3.0.0",
-            "array-uniq": "^1.0.3",
-            "camelcase": "^4.1.0",
-            "chalk": "^2.3.2",
-            "cheerio": "^1.0.0-rc.2",
-            "detect-indent": "^5.0.0",
-            "he": "^1.1.1",
-            "highlight.js": "^9.12.0",
-            "lodash.merge": "^4.6.2",
-            "min-indent": "^1.0.0",
-            "strip-ansi": "^4.0.0",
-            "strip-indent": "^2.0.0",
-            "super-split": "^1.1.0"
-          }
-        },
         "@types/node": {
-          "version": "10.17.44",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
-        },
-        "aes-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "axios": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-          "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "version": "10.17.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+          "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
         },
         "eth-lib": {
           "version": "0.2.7",
@@ -2212,316 +2046,191 @@
             }
           }
         },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.9",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+            },
+            "ethereumjs-util": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.3"
+              }
+            }
+          }
+        },
         "eventemitter3": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
         },
-        "follow-redirects": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-          "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "openzeppelin-solidity": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.5.1.tgz",
-          "integrity": "sha512-oCGtQPLOou4su76IMr4XXJavy9a8OZmAXeUZ8diOdFznlL/mlkIlYr7wajqCzH4S47nlKPS7m0+a2nilCTpVPQ=="
-        },
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "scryptsy": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-          "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.9",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-            }
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "solc": {
-          "version": "0.5.14",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.14.tgz",
-          "integrity": "sha512-I/MCeOKjnLXxcD65wA+E37BxdERoAYoLeyJ5GnXFijICLmvhzt0xz59R92Zw3TPyJYnHSErKBYpMsfnZVyQJaQ==",
-          "requires": {
-            "command-exists": "^1.2.8",
-            "commander": "3.0.2",
-            "fs-extra": "^0.30.0",
-            "js-sha3": "0.8.0",
-            "memorystream": "^0.3.1",
-            "require-from-string": "^2.0.0",
-            "semver": "^5.5.0",
-            "tmp": "0.0.33"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "synthetix": {
-          "version": "2.27.4",
-          "resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.27.4.tgz",
-          "integrity": "sha512-/ll0ZBWlIwx37jGyWS4+sMZBBtOzNJyyt70FxjFg41CKBD94KTN6ocllp/BUpdwc9UcU6LyoinWNR5oHRUUgrA==",
-          "requires": {
-            "@chainlink/contracts-0.0.9": "npm:@chainlink/contracts@0.0.9",
-            "abi-decoder": "2.3.0",
-            "commander": "5.1.0",
-            "openzeppelin-solidity-2.3.0": "npm:openzeppelin-solidity@2.3.0",
-            "pretty-error": "^2.1.1",
-            "solidity-parser-antlr": "^0.4.11",
-            "web3-utils": "1.2.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            },
-            "commander": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-              "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-            },
-            "web3-utils": {
-              "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
-              "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
-              "requires": {
-                "bn.js": "4.11.8",
-                "eth-lib": "0.2.7",
-                "ethereum-bloom-filters": "^1.0.6",
-                "ethjs-unit": "0.1.6",
-                "number-to-bn": "1.7.0",
-                "randombytes": "^2.1.0",
-                "underscore": "1.9.1",
-                "utf8": "3.0.0"
-              }
-            }
-          }
-        },
-        "synthetix-js": {
-          "version": "2.27.4",
-          "resolved": "https://registry.npmjs.org/synthetix-js/-/synthetix-js-2.27.4.tgz",
-          "integrity": "sha512-mDyrB7AycqQmZe5j/TfmbN4GaY5hI7Cr9aIGv+GF7iRLAHfAuqQk96AzzZT9OOxF7zXTCjxSwFmZlYb7vzOIcQ==",
-          "requires": {
-            "@ledgerhq/hw-app-eth": "4.74.2",
-            "@ledgerhq/hw-transport": "4.74.2",
-            "@ledgerhq/hw-transport-u2f": "4.74.2",
-            "@portis/web3": "^2.0.0-beta.59",
-            "@walletconnect/web3-provider": "^1.0.15",
-            "ethereumjs-tx": "1.3.7",
-            "ethereumjs-util": "5.2.0",
-            "ethers": "4.0.44",
-            "hdkey": "1.1.1",
-            "lodash": "4.17.15",
-            "synthetix": "2.27.4",
-            "trezor-connect": "8.1.8",
-            "walletlink": "2.0.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.9",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-            },
-            "elliptic": {
-              "version": "6.5.2",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
-            },
-            "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
-              }
-            },
-            "ethers": {
-              "version": "4.0.44",
-              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.44.tgz",
-              "integrity": "sha512-kCkMPkpYjBkxzqjcuYUfDY7VHDbf5EXnfRPUOazdqdf59SvXaT+w5lgauxLlk1UjxnAiNfeNS87rkIXnsTaM7Q==",
-              "requires": {
-                "aes-js": "3.0.0",
-                "bn.js": "^4.4.0",
-                "elliptic": "6.5.2",
-                "hash.js": "1.1.3",
-                "js-sha3": "0.5.7",
-                "scrypt-js": "2.0.4",
-                "setimmediate": "1.0.4",
-                "uuid": "2.0.1",
-                "xmlhttprequest": "1.8.0"
-              }
-            },
-            "js-sha3": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-            },
-            "scrypt-js": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-              "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-            },
-            "setimmediate": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-            }
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        },
         "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "web3": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
-          "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.9.tgz",
+          "integrity": "sha512-Mo5aBRm0JrcNpN/g4VOrDzudymfOnHRC3s2VarhYxRA8aWgF5rnhQ0ziySaugpic1gksbXPe105pUWyRqw8HUA==",
           "requires": {
-            "web3-bzz": "1.2.1",
-            "web3-core": "1.2.1",
-            "web3-eth": "1.2.1",
-            "web3-eth-personal": "1.2.1",
-            "web3-net": "1.2.1",
-            "web3-shh": "1.2.1",
-            "web3-utils": "1.2.1"
+            "web3-bzz": "1.2.9",
+            "web3-core": "1.2.9",
+            "web3-eth": "1.2.9",
+            "web3-eth-personal": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-shh": "1.2.9",
+            "web3-utils": "1.2.9"
           }
         },
         "web3-bzz": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
-          "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.9.tgz",
+          "integrity": "sha512-ogVQr9jHodu9HobARtvUSmWG22cv2EUQzlPeejGWZ7j5h20HX40EDuWyomGY5VclIj5DdLY76Tmq88RTf/6nxA==",
           "requires": {
+            "@types/node": "^10.12.18",
             "got": "9.6.0",
-            "swarm-js": "0.1.39",
+            "swarm-js": "^0.1.40",
             "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.9.tgz",
+          "integrity": "sha512-fSYv21IP658Ty2wAuU9iqmW7V+75DOYMVZsDH/c14jcF/1VXnedOcxzxSj3vArsCvXZNe6XC5/wAuGZyQwR9RA==",
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-requestmanager": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.19.8",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
+              "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.9.tgz",
+          "integrity": "sha512-t0WAG3orLCE3lqi77ZoSRNFok3VQWZXTniZigDQjyOJYMAX7BU3F3js8HKbjVnAxlX3tiKoDxI0KBk9F3AxYuw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.9.tgz",
+          "integrity": "sha512-bjsIoqP3gs7A/gP8+QeLUCyOKJ8bopteCSNbCX36Pxk6TYfYWNuC6hP+2GzUuqdP3xaZNe+XEElQFUNpR3oyAg==",
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.9.tgz",
+          "integrity": "sha512-0eAUA2zjgXTleSrnc1wdoKQPPIHU6KHf4fAscu4W9kKrR+mqP1KsjYrxY9wUyjNnXxfQ+5M29ipvbiaK8OqdOw==",
+          "requires": {
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.9.tgz",
+          "integrity": "sha512-1PwKV2m46ALUnIN5VPPgjOj8yMLJhhqZYvYJE34hTN5SErOkwhzx5zScvo5MN7v7KyQGFnpVCZKKGCiEnDmtFA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9",
+            "web3-providers-http": "1.2.9",
+            "web3-providers-ipc": "1.2.9",
+            "web3-providers-ws": "1.2.9"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.9.tgz",
+          "integrity": "sha512-Y48TvXPSPxEM33OmXjGVDMzTd0j8X0t2+sDw66haeBS8eYnrEzasWuBZZXDq0zNUsqyxItgBGDn+cszkgEnFqg==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.9"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.9.tgz",
+          "integrity": "sha512-sIKO4iE9FEBa/CYUd6GdPd7GXt/wISqxUd8PlIld6+hvMJj02lgO7Z7p5T9mZIJcIZJGvZX81ogx8oJ9yif+Ag==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-eth-accounts": "1.2.9",
+            "web3-eth-contract": "1.2.9",
+            "web3-eth-ens": "1.2.9",
+            "web3-eth-iban": "1.2.9",
+            "web3-eth-personal": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.9.tgz",
+          "integrity": "sha512-3YwUYbh/DMfDbhMWEebAdjSd5bj3ZQieOjLzWFHU23CaLEqT34sUix1lba+hgUH/EN6A7bKAuKOhR3p0OvTn7Q==",
+          "requires": {
+            "@ethersproject/abi": "5.0.0-beta.153",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.9"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.9.tgz",
+          "integrity": "sha512-jkbDCZoA1qv53mFcRHCinoCsgg8WH+M0YUO1awxmqWXRmCRws1wW0TsuSQ14UThih5Dxolgl+e+aGWxG58LMwg==",
+          "requires": {
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "^0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-utils": "1.2.9"
           },
           "dependencies": {
             "bn.js": {
@@ -2530,291 +2239,56 @@
               "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
             },
             "eth-lib": {
-              "version": "0.1.29",
-              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-              "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
-                "nano-json-stream-parser": "^0.1.2",
-                "servify": "^0.1.12",
-                "ws": "^3.0.0",
                 "xhr-request-promise": "^0.1.2"
               }
-            },
-            "fs-extra": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-              "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            },
-            "jsonfile": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            },
-            "swarm-js": {
-              "version": "0.1.39",
-              "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
-              "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
-              "requires": {
-                "bluebird": "^3.5.0",
-                "buffer": "^5.0.5",
-                "decompress": "^4.0.0",
-                "eth-lib": "^0.1.26",
-                "fs-extra": "^4.0.2",
-                "got": "^7.1.0",
-                "mime-types": "^2.1.16",
-                "mkdirp-promise": "^5.0.1",
-                "mock-fs": "^4.1.0",
-                "setimmediate": "^1.0.5",
-                "tar": "^4.0.2",
-                "xhr-request-promise": "^0.1.2"
-              },
-              "dependencies": {
-                "got": {
-                  "version": "7.1.0",
-                  "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-                  "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-                  "requires": {
-                    "decompress-response": "^3.2.0",
-                    "duplexer3": "^0.1.4",
-                    "get-stream": "^3.0.0",
-                    "is-plain-obj": "^1.1.0",
-                    "is-retry-allowed": "^1.0.0",
-                    "is-stream": "^1.0.0",
-                    "isurl": "^1.0.0-alpha5",
-                    "lowercase-keys": "^1.0.0",
-                    "p-cancelable": "^0.3.0",
-                    "p-timeout": "^1.1.1",
-                    "safe-buffer": "^5.0.1",
-                    "timed-out": "^4.0.0",
-                    "url-parse-lax": "^1.0.0",
-                    "url-to-options": "^1.0.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "web3-core": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
-          "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
-          "requires": {
-            "web3-core-helpers": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-core-requestmanager": "1.2.1",
-            "web3-utils": "1.2.1"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
-          "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-eth-iban": "1.2.1",
-            "web3-utils": "1.2.1"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
-          "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-promievent": "1.2.1",
-            "web3-core-subscriptions": "1.2.1",
-            "web3-utils": "1.2.1"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
-          "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "eventemitter3": "3.1.2"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
-          "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-providers-http": "1.2.1",
-            "web3-providers-ipc": "1.2.1",
-            "web3-providers-ws": "1.2.1"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
-          "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
-          "requires": {
-            "eventemitter3": "3.1.2",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
-          }
-        },
-        "web3-eth": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
-          "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core": "1.2.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-core-subscriptions": "1.2.1",
-            "web3-eth-abi": "1.2.1",
-            "web3-eth-accounts": "1.2.1",
-            "web3-eth-contract": "1.2.1",
-            "web3-eth-ens": "1.2.1",
-            "web3-eth-iban": "1.2.1",
-            "web3-eth-personal": "1.2.1",
-            "web3-net": "1.2.1",
-            "web3-utils": "1.2.1"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
-          "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
-          "requires": {
-            "ethers": "4.0.0-beta.3",
-            "underscore": "1.9.1",
-            "web3-utils": "1.2.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.9",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-            },
-            "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
-              }
-            },
-            "ethers": {
-              "version": "4.0.0-beta.3",
-              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
-              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
-              "requires": {
-                "@types/node": "^10.3.2",
-                "aes-js": "3.0.0",
-                "bn.js": "^4.4.0",
-                "elliptic": "6.3.3",
-                "hash.js": "1.1.3",
-                "js-sha3": "0.5.7",
-                "scrypt-js": "2.0.3",
-                "setimmediate": "1.0.4",
-                "uuid": "2.0.1",
-                "xmlhttprequest": "1.8.0"
-              }
-            },
-            "js-sha3": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-              "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-            },
-            "scrypt-js": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-              "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
-            },
-            "setimmediate": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-            }
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
-          "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "scryptsy": "2.1.0",
-            "semver": "6.2.0",
-            "underscore": "1.9.1",
-            "uuid": "3.3.2",
-            "web3-core": "1.2.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-utils": "1.2.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-              "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
             }
           }
         },
         "web3-eth-contract": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
-          "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.9.tgz",
+          "integrity": "sha512-PYMvJf7EG/HyssUZa+pXrc8IB06K/YFfWYyW4R7ed3sab+9wWUys1TlWxBCBuiBXOokSAyM6H6P6/cKEx8FT8Q==",
           "requires": {
+            "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
-            "web3-core": "1.2.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-core-promievent": "1.2.1",
-            "web3-core-subscriptions": "1.2.1",
-            "web3-eth-abi": "1.2.1",
-            "web3-utils": "1.2.1"
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-utils": "1.2.9"
           }
         },
         "web3-eth-ens": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
-          "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.9.tgz",
+          "integrity": "sha512-kG4+ZRgZ8I1WYyOBGI8QVRHfUSbbJjvJAGA1AF/NOW7JXQ+x7gBGeJw6taDWJhSshMoEKWcsgvsiuoG4870YxQ==",
           "requires": {
+            "content-hash": "^2.5.2",
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
-            "web3-core": "1.2.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-promievent": "1.2.1",
-            "web3-eth-abi": "1.2.1",
-            "web3-eth-contract": "1.2.1",
-            "web3-utils": "1.2.1"
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-promievent": "1.2.9",
+            "web3-eth-abi": "1.2.9",
+            "web3-eth-contract": "1.2.9",
+            "web3-utils": "1.2.9"
           }
         },
         "web3-eth-iban": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
-          "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.9.tgz",
+          "integrity": "sha512-RtdVvJE0pyg9dHLy0GzDiqgnLnssSzfz/JYguhC1wsj9+Gnq1M6Diy3NixACWUAp6ty/zafyOaZnNQ+JuH9TjQ==",
           "requires": {
             "bn.js": "4.11.8",
-            "web3-utils": "1.2.1"
+            "web3-utils": "1.2.9"
           },
           "dependencies": {
             "bn.js": {
@@ -2825,98 +2299,94 @@
           }
         },
         "web3-eth-personal": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
-          "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.9.tgz",
+          "integrity": "sha512-cFiNrktxZ1C/rIdJFzQTvFn3/0zcsR3a+Jf8Y3KxeQDHszQtosjLWptP7bsUmDwEh4hzh0Cy3KpOxlYBWB8bJQ==",
           "requires": {
-            "web3-core": "1.2.1",
-            "web3-core-helpers": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-net": "1.2.1",
-            "web3-utils": "1.2.1"
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.9",
+            "web3-core-helpers": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-net": "1.2.9",
+            "web3-utils": "1.2.9"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "12.19.8",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
+              "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
+            }
           }
         },
         "web3-net": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
-          "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.9.tgz",
+          "integrity": "sha512-d2mTn8jPlg+SI2hTj2b32Qan6DmtU9ap/IUlJTeQbZQSkTLf0u9suW8Vjwyr4poJYXTurdSshE7OZsPNn30/ZA==",
           "requires": {
-            "web3-core": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-utils": "1.2.1"
+            "web3-core": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-utils": "1.2.9"
           }
         },
         "web3-providers-http": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
-          "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.9.tgz",
+          "integrity": "sha512-F956tCIj60Ttr0UvEHWFIhx+be3He8msoPzyA44/kfzzYoMAsCFRn5cf0zQG6al0znE75g6HlWVSN6s3yAh51A==",
           "requires": {
-            "web3-core-helpers": "1.2.1",
+            "web3-core-helpers": "1.2.9",
             "xhr2-cookies": "1.1.0"
           }
         },
         "web3-providers-ipc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
-          "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.9.tgz",
+          "integrity": "sha512-NQ8QnBleoHA2qTJlqoWu7EJAD/FR5uimf7Ielzk4Z2z+m+6UAuJdJMSuQNj+Umhz9L/Ys6vpS1vHx9NizFl+aQ==",
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.9"
           }
         },
         "web3-providers-ws": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
-          "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.9.tgz",
+          "integrity": "sha512-6+UpvINeI//dglZoAKStUXqxDOXJy6Iitv2z3dbgInG4zb8tkYl/VBDL80UjUg3ZvzWG0g7EKY2nRPEpON2TFA==",
           "requires": {
+            "eventemitter3": "^4.0.0",
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+            "web3-core-helpers": "1.2.9",
+            "websocket": "^1.0.31"
           },
           "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "websocket": {
-              "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
-              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-              "requires": {
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "nan": "^2.14.0",
-                "typedarray-to-buffer": "^3.1.5",
-                "yaeti": "^0.0.6"
-              }
+            "eventemitter3": {
+              "version": "4.0.7",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+              "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
             }
           }
         },
         "web3-shh": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
-          "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.9.tgz",
+          "integrity": "sha512-PWa8b/EaxaMinFaxy6cV0i0EOi2M7a/ST+9k9nhyhCjVa2vzXuNoBNo2IUOmeZ0WP2UQB8ByJ2+p4htlJaDOjA==",
           "requires": {
-            "web3-core": "1.2.1",
-            "web3-core-method": "1.2.1",
-            "web3-core-subscriptions": "1.2.1",
-            "web3-net": "1.2.1"
+            "web3-core": "1.2.9",
+            "web3-core-method": "1.2.9",
+            "web3-core-subscriptions": "1.2.9",
+            "web3-net": "1.2.9"
           }
         },
         "web3-utils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
-          "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+          "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
             "ethjs-unit": "0.1.6",
             "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
+            "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
           },
@@ -2926,16 +2396,6 @@
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
             }
-          }
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
           }
         }
       }
@@ -2955,10 +2415,41 @@
         }
       }
     },
+    "@gnosis.pm/owl-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/owl-token/-/owl-token-4.0.0.tgz",
+      "integrity": "sha512-Ia+3BwEqcywlGbg1s3EU8l40ZkP/hiKDr8A8lQb705iIE2pSqakG1NhwswExuNYMnwAK5AvplVRa5Fs0K5UFZA==",
+      "requires": {
+        "@gnosis.pm/gno-token": "^2.0.0",
+        "@gnosis.pm/util-contracts": "^2.0.0",
+        "openzeppelin-solidity": "1.12.0",
+        "verify-on-etherscan": "^1.1.1"
+      }
+    },
     "@gnosis.pm/safe-apps-sdk": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-0.3.1.tgz",
       "integrity": "sha512-2nsmoaPa/C3X+g6EThc4DD7ptSy9fV+RQ507Ly1y01uIzVMRCT0sFcOm0z8oNwCWc5qtY2X4hn00+oR6JdmhUw=="
+    },
+    "@gnosis.pm/safe-contracts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/safe-contracts/-/safe-contracts-1.2.0.tgz",
+      "integrity": "sha512-lcpZodqztDgMICB0kAc8aJdQePwCaLJnbeNjgVTfLAo3fBckVRV06VHXg5IsZ26qLA4JfZ690Cb7TsDVE9ZF3w==",
+      "requires": {
+        "@truffle/hdwallet-provider": "^1.0.0",
+        "dotenv": "^8.0.0",
+        "openzeppelin-solidity": "^2.0.0",
+        "shelljs": "^0.8.3",
+        "solc": "0.5.17",
+        "truffle": "^5.1.21"
+      },
+      "dependencies": {
+        "openzeppelin-solidity": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.5.1.tgz",
+          "integrity": "sha512-oCGtQPLOou4su76IMr4XXJavy9a8OZmAXeUZ8diOdFznlL/mlkIlYr7wajqCzH4S47nlKPS7m0+a2nilCTpVPQ=="
+        }
+      }
     },
     "@gnosis.pm/safe-react-components": {
       "version": "github:gnosis/safe-react-components#1bf397f2bc48ba48906824137943f0bb5804c99c",
@@ -3737,9 +3228,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -3761,9 +3252,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -3786,9 +3277,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -3811,9 +3302,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -3849,9 +3340,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.1.tgz",
-      "integrity": "sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.2.tgz",
+      "integrity": "sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ=="
     },
     "@storybook/addon-actions": {
       "version": "6.0.26",
@@ -5674,9 +5165,9 @@
       "dev": true
     },
     "@truffle/hdwallet-provider": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.1.1.tgz",
-      "integrity": "sha512-Gw5lk2dUs6NhLcaF49FuuL3Qv1Setpgr9uUhf7voIS/1OD4ar2CW9Zv7QJiR5m0PD/b8SUqbIckq0evY4Mendg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.2.0.tgz",
+      "integrity": "sha512-EPatDbyRuGbB/MLt9ZBokmtjyLjaNpuHfUIWuv4mQMrH1Nu82H5AAZYLh4Z1BZliDZpqB03a0yUMmK/4R0BN9g==",
       "requires": {
         "@trufflesuite/web3-provider-engine": "15.0.13-1",
         "@types/web3": "^1.0.20",
@@ -9143,9 +8634,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "mkdirp": {
           "version": "0.5.5",
@@ -9180,9 +8671,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "regenerator-runtime": {
           "version": "0.11.1",
@@ -11855,12 +11346,11 @@
       "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
     },
     "csv-parser": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.3.tgz",
-      "integrity": "sha512-czcyxc4/3Tt63w0oiK1zsnRgRD4PkqWaRSJ6eef63xC0f+5LVLuGdSYEcJwGp2euPgRHx+jmlH2Lb49anb1CGQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.4.tgz",
+      "integrity": "sha512-UlzYZEiHR5OQTh0C97HeZfSBOCshKIe0NpG5vYlgAcXheDKvZoIHvZNMgg1IGvtvbSKVRB6/UIA4xxjzKi2TFA==",
       "requires": {
-        "minimist": "^1.2.0",
-        "through2": "^3.0.1"
+        "minimist": "^1.2.0"
       }
     },
     "csv-writer": {
@@ -14367,15 +13857,6 @@
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
           }
         }
       }
@@ -17370,9 +16851,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.44",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
+          "version": "10.17.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+          "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
         }
       }
     },
@@ -20158,9 +19639,9 @@
       "dev": true
     },
     "json-rpc-engine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.3.0.tgz",
-      "integrity": "sha512-+diJ9s8rxB+fbJhT7ZEf8r8spaLRignLd8jTgQ/h5JSGppAHGtNMZtCoabipCaleR1B3GTGxbXBOqhaJSGmPGQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
+      "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
       "requires": {
         "eth-rpc-errors": "^3.0.0",
         "safe-event-emitter": "^1.0.1"
@@ -21766,11 +21247,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "p-limit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^0.1.0"
           }
         },
         "p-locate": {
@@ -22532,6 +22013,11 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
+    },
+    "openzeppelin-solidity": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz",
+      "integrity": "sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA=="
     },
     "openzeppelin-solidity-2.3.0": {
       "version": "npm:openzeppelin-solidity@2.3.0",
@@ -26409,6 +25895,48 @@
         }
       }
     },
+    "solc": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.17.tgz",
+      "integrity": "sha512-qpX+PGaU0Q3c6lh2vDzMoIbhv6bIrecI4bYsx+xUs01xsGFnY6Nr0L8y/QMyutTnrHN6Lb/Yl672ZVRqxka96w==",
+      "requires": {
+        "command-exists": "^1.2.8",
+        "commander": "3.0.2",
+        "fs-extra": "^0.30.0",
+        "js-sha3": "0.8.0",
+        "memorystream": "^0.3.1",
+        "require-from-string": "^2.0.0",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "solidity-parser-antlr": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
@@ -26917,12 +26445,13 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz",
-      "integrity": "sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.3.tgz",
+      "integrity": "sha512-16IL9pIBA5asNOSukPfxX2W68BaBvxyiRK16H3RA/lWW9BDosh+w7f+LhomPHpXJ82QEe7w7/rY/S1CV97raLg==",
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0"
+        "es-abstract": "^1.18.0-next.1"
       },
       "dependencies": {
         "es-abstract": {
@@ -27371,6 +26900,195 @@
         "get-port": "^3.1.0"
       }
     },
+    "synthetix": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/synthetix/-/synthetix-2.30.1.tgz",
+      "integrity": "sha512-1y8bLw3L4GPzVb9Z7yUHqWSSXmfUQbYHOwQb1Pwc0dSM+qIjopT6sY3vaL0HbTy+jemhPXcaP+fFZY4UqppFmw==",
+      "requires": {
+        "@chainlink/contracts-0.0.10": "npm:@chainlink/contracts@0.0.10",
+        "abi-decoder": "2.3.0",
+        "commander": "5.1.0",
+        "openzeppelin-solidity-2.3.0": "npm:openzeppelin-solidity@2.3.0",
+        "pretty-error": "^2.1.1",
+        "solidity-parser-antlr": "^0.4.11",
+        "web3-utils": "1.2.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "synthetix-js": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/synthetix-js/-/synthetix-js-2.30.1.tgz",
+      "integrity": "sha512-ijFOgihCACZ8/C63TDU+ZvR0jjMMcVqVmInWsS87eB6wdhjlKgJzCBGo3NQTaiB9CtSf4YkC9tA+W/opZk3TDA==",
+      "requires": {
+        "@ledgerhq/hw-app-eth": "4.74.2",
+        "@ledgerhq/hw-transport": "4.74.2",
+        "@ledgerhq/hw-transport-u2f": "4.74.2",
+        "@portis/web3": "^2.0.0-beta.59",
+        "@walletconnect/web3-provider": "^1.0.15",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "ethers": "4.0.44",
+        "hdkey": "1.1.1",
+        "lodash": "4.17.15",
+        "synthetix": "2.30.1",
+        "trezor-connect": "8.1.8",
+        "walletlink": "2.0.2"
+      },
+      "dependencies": {
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+        },
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.44",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.44.tgz",
+          "integrity": "sha512-kCkMPkpYjBkxzqjcuYUfDY7VHDbf5EXnfRPUOazdqdf59SvXaT+w5lgauxLlk1UjxnAiNfeNS87rkIXnsTaM7Q==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
+      }
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -27679,12 +27397,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "thunky": {
@@ -27856,9 +27574,9 @@
       },
       "dependencies": {
         "whatwg-fetch": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-          "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+          "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
         }
       }
     },
@@ -27912,9 +27630,9 @@
       "dev": true
     },
     "truffle": {
-      "version": "5.1.51",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.51.tgz",
-      "integrity": "sha512-Sbw+FF2AfEvkcL/iOFm8UQPfuAfQ695UgxRliBE5sb7WoIN1IwRS0l0Cw+n8XOhkLTxOpoFtVEmrbdqWkZTz7g==",
+      "version": "5.1.55",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.55.tgz",
+      "integrity": "sha512-chZM43DOo7aCn+z1Pcj5f4ts9YqnHhKI31CZ+B6N93nbWKnIrBN/hBZeEXSi9s9FZ3nsmp+Iplr5Z4dnHAqDxA==",
       "requires": {
         "app-module-path": "^2.2.0",
         "mocha": "8.1.2",
@@ -27945,9 +27663,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.44",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
+          "version": "10.17.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+          "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
         },
         "aes-js": {
           "version": "3.0.0",
@@ -31596,6 +31314,11 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@gnosis.pm/dex-contracts": "^0.4.1",
     "@gnosis.pm/dex-js": "^0.4.1",
-    "@gnosis.pm/dex-liquidity-provision": "github:gnosis/dex-liquidity-provision#fix/add-withdraw-helper-to-wrapper",
+    "@gnosis.pm/dex-liquidity-provision": "github:gnosis/dex-liquidity-provision#8ec9ba3c7a9b17ec743b7e983ff8a0b46d2d509d",
     "@gnosis.pm/safe-apps-sdk": "^0.3.1",
     "@gnosis.pm/safe-react-components": "gnosis/safe-react-components#development",
     "@hot-loader/react-dom": "^16.13.0",


### PR DESCRIPTION
# Description

Pinning dex-liquidity-provision commit to avoid rolling back

Without the change in this commit, xDai withdraws don't work.

Diff between #201 and latest #master branch:
![screenshot_2020-12-01_11-09-00](https://user-images.githubusercontent.com/43217/100785495-923d5900-33c5-11eb-9e7d-f1395fabe8c4.png)



# To Test
1. On xDai, go to strategies tab
1. Request withdraw of an active strategy

- [ ] Safe tx modal should pop up

# Background

For some reason, package-lock rolled back `dex-liquidity-provision` to a previous version which doesn't contain the changes required to run xDai.
This change pins the latest commit in the branch [8ec9ba3c7a9b17ec743b7e983ff8a0b46d2d509d](https://github.com/gnosis/dex-liquidity-provision/commits/fix/add-withdraw-helper-to-wrapper)

