### PR TITLE
Infinity APR

### DIFF
--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,4 +1,5 @@
 import Decimal from "decimal.js";
+import { ZERO_DECIMAL } from "./constants";
 
 import { dateDiffInDays } from "./time";
 
@@ -67,6 +68,11 @@ export function calculateApr(
   const difference = currentValue.minus(initialValue);
 
   const days = dateDiffInDays(startDate, _endDate);
+
+  if (days === 0) {
+    return ZERO_DECIMAL;
+  }
+
   const differencePerDay = difference.div(initialValue).div(days);
 
   return differencePerDay.mul("365");

--- a/test/utils/calculateApr.test.ts
+++ b/test/utils/calculateApr.test.ts
@@ -76,4 +76,14 @@ describe("Valid input", () => {
       calculateApr(currentValue, initialValue, startDate, endDate)
     ).toEqual(ONE_DECIMAL.div(ONE_HUNDRED_DECIMAL).times("365"));
   });
+
+  test("Start date === end date", () => {
+    const initialValue = ONE_HUNDRED_DECIMAL;
+    const currentValue = ONE_HUNDRED_DECIMAL.add(ONE_DECIMAL);
+    const endDate = startDate;
+
+    expect(
+      calculateApr(currentValue, initialValue, startDate, endDate)
+    ).toEqual(ZERO_DECIMAL);
+  });
 });


### PR DESCRIPTION
# Description

Fixes #188 

When days since creation is 0 (for APR calculation), simply return 0, instead of trying to divide by 0.

# To Test
1. Deploy a new strategy
1. Go to strategies
1. Expand the strategy

- [ ] APR should be 0.0% (instead of `infinity`)

# Background

N/A

