### PR TITLE
Bug/#213/fix prices

### DIFF
--- a/src/components/basic/display/BracketsView/Footer.tsx
+++ b/src/components/basic/display/BracketsView/Footer.tsx
@@ -29,7 +29,7 @@ const TwoPrices = styled.span`
 
 export const Footer = memo(function Footer(): JSX.Element {
   const {
-    baseTokenAddress,
+    quoteTokenAddress,
     startPrice,
     lowestPrice,
     highestPrice,
@@ -51,7 +51,7 @@ export const Footer = memo(function Footer(): JSX.Element {
         startPrice && (
           <PriceDisplay
             price={startPrice}
-            token={baseTokenAddress}
+            token={quoteTokenAddress}
             adornment={adornment}
             color="primary"
             size="xs"
@@ -61,29 +61,29 @@ export const Footer = memo(function Footer(): JSX.Element {
         )
       );
     },
-    [baseTokenAddress, startPrice]
+    [quoteTokenAddress, startPrice]
   );
 
   const lowestPriceDisplay = useMemo(() => {
     return (
       lowestPrice && (
-        <PriceDisplay price={lowestPrice} token={baseTokenAddress} size="xs" />
+        <PriceDisplay price={lowestPrice} token={quoteTokenAddress} size="xs" />
       )
     );
-  }, [baseTokenAddress, lowestPrice]);
+  }, [quoteTokenAddress, lowestPrice]);
 
   const highestPriceDisplay = useMemo(() => {
     return (
       highestPrice && (
         <PriceDisplay
           price={highestPrice}
-          token={baseTokenAddress}
+          token={quoteTokenAddress}
           size="xs"
           className="justifyRight"
         />
       )
     );
-  }, [baseTokenAddress, highestPrice]);
+  }, [quoteTokenAddress, highestPrice]);
 
   const leftSide = useMemo(() => {
     if (needlePosition < 0) {

--- a/src/components/basic/display/BracketsView/Footer.tsx
+++ b/src/components/basic/display/BracketsView/Footer.tsx
@@ -51,7 +51,7 @@ export const Footer = memo(function Footer(): JSX.Element {
         startPrice && (
           <PriceDisplay
             price={startPrice}
-            token={quoteTokenAddress}
+            quoteToken={quoteTokenAddress}
             adornment={adornment}
             color="primary"
             size="xs"
@@ -67,7 +67,11 @@ export const Footer = memo(function Footer(): JSX.Element {
   const lowestPriceDisplay = useMemo(() => {
     return (
       lowestPrice && (
-        <PriceDisplay price={lowestPrice} token={quoteTokenAddress} size="xs" />
+        <PriceDisplay
+          price={lowestPrice}
+          quoteToken={quoteTokenAddress}
+          size="xs"
+        />
       )
     );
   }, [quoteTokenAddress, lowestPrice]);
@@ -77,7 +81,7 @@ export const Footer = memo(function Footer(): JSX.Element {
       highestPrice && (
         <PriceDisplay
           price={highestPrice}
-          token={quoteTokenAddress}
+          quoteToken={quoteTokenAddress}
           size="xs"
           className="justifyRight"
         />

--- a/src/components/basic/display/BracketsView/Needle.tsx
+++ b/src/components/basic/display/BracketsView/Needle.tsx
@@ -34,7 +34,7 @@ export const Needle = memo(function Needle(): JSX.Element {
   const {
     needlePosition = 50,
     startPrice,
-    baseTokenAddress,
+    quoteTokenAddress,
     lowerThreshold,
     upperThreshold,
   } = useContext(BracketsViewContext);
@@ -51,7 +51,7 @@ export const Needle = memo(function Needle(): JSX.Element {
           {startPrice && (
             <PriceDisplay
               price={startPrice}
-              token={baseTokenAddress}
+              token={quoteTokenAddress}
               color="primary"
               size="xs"
               className="price"

--- a/src/components/basic/display/BracketsView/Needle.tsx
+++ b/src/components/basic/display/BracketsView/Needle.tsx
@@ -51,7 +51,7 @@ export const Needle = memo(function Needle(): JSX.Element {
           {startPrice && (
             <PriceDisplay
               price={startPrice}
-              token={quoteTokenAddress}
+              quoteToken={quoteTokenAddress}
               color="primary"
               size="xs"
               className="price"

--- a/src/components/basic/display/BracketsView/PriceDisplay.tsx
+++ b/src/components/basic/display/BracketsView/PriceDisplay.tsx
@@ -7,7 +7,7 @@ import { TokenDisplay } from "../TokenDisplay";
 
 export type Props = {
   price?: string;
-  token?: string;
+  quoteToken?: string;
   color?: "primary" | "text";
   size?: "sm" | "xs";
   className?: string;
@@ -28,7 +28,7 @@ export const PriceDisplay = memo(function PriceDisplay(
 ): JSX.Element {
   const {
     price,
-    token,
+    quoteToken,
     className,
     color = "text",
     size = "sm",
@@ -46,7 +46,9 @@ export const PriceDisplay = memo(function PriceDisplay(
       <Text size={size} as="span" color={color}>
         {price}
       </Text>
-      {token && <TokenDisplay token={token} size={size} color={color} />}
+      {quoteToken && (
+        <TokenDisplay token={quoteToken} size={size} color={color} />
+      )}
       {isOutOfRange && (
         <Text size={size} color="rinkeby">
           (out of range)

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -130,7 +130,7 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
               {...input}
               warn={meta.touched && meta.data?.warn}
               error={meta.touched && meta.error}
-              tokenAddress={baseTokenAddress}
+              tokenAddress={quoteTokenAddress}
               labelText="Lowest price"
               labelTooltip="The lowest price our strategy covers, lower than this you hold 100% token B"
             />
@@ -170,7 +170,7 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
               {...input}
               warn={meta.touched && meta.data?.warn}
               error={meta.touched && meta.error}
-              tokenAddress={baseTokenAddress}
+              tokenAddress={quoteTokenAddress}
               labelText="Start Price"
               labelTooltip="Below the start price, brackets will be funded with token A. Above the start price, brackets will be funded with token B."
               labelSize="xl"
@@ -211,7 +211,7 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
               {...input}
               warn={meta.touched && meta.data?.warn}
               error={meta.touched && meta.error}
-              tokenAddress={baseTokenAddress}
+              tokenAddress={quoteTokenAddress}
               labelText="Highest price"
               labelTooltip="The max price per token A you are willing to sell or buy"
             />

--- a/src/components/pages/strategies/Active/ActiveTable.tsx
+++ b/src/components/pages/strategies/Active/ActiveTable.tsx
@@ -89,7 +89,7 @@ export const ActiveTable = memo(function ActiveTable({
                 <TableCell>{strategy.created.toLocaleString()}</TableCell>
                 <TableCell>
                   {strategy.quoteToken && strategy.baseToken
-                    ? `${strategy.quoteToken?.symbol} - ${strategy.baseToken?.symbol}`
+                    ? `${strategy.baseToken?.symbol} - ${strategy.quoteToken?.symbol}`
                     : "Unknown"}
                 </TableCell>
                 <TableCell>{strategy.brackets.length}</TableCell>

--- a/src/components/pages/strategies/Closed/ClosedTable.tsx
+++ b/src/components/pages/strategies/Closed/ClosedTable.tsx
@@ -104,7 +104,7 @@ export const ClosedTable = memo(function ClosedTable({
                 <TableCell>{strategy.created.toLocaleString()}</TableCell>
                 <TableCell>
                   {strategy.quoteToken && strategy.baseToken
-                    ? `${strategy.quoteToken?.symbol} - ${strategy.baseToken?.symbol}`
+                    ? `${strategy.baseToken?.symbol} - ${strategy.quoteToken?.symbol}`
                     : "Unknown"}
                 </TableCell>
                 <TableCell>

--- a/src/components/pages/strategies/Pending/PendingTable.tsx
+++ b/src/components/pages/strategies/Pending/PendingTable.tsx
@@ -87,7 +87,7 @@ export const PendingTable = memo(function PendingTable({
                 <TableCell>{strategy.created.toLocaleString()}</TableCell>
                 <TableCell>
                   {strategy.quoteToken && strategy.baseToken
-                    ? `${strategy.quoteToken?.symbol} - ${strategy.baseToken?.symbol}`
+                    ? `${strategy.baseToken?.symbol} - ${strategy.quoteToken?.symbol}`
                     : "Unknown"}
                 </TableCell>
                 <TableCell>{strategy.nonce}</TableCell>


### PR DESCRIPTION
# Description

Fixes #213 

Prices labels are correctly set to `Token B`
![screenshot_2020-12-04_11-19-41](https://user-images.githubusercontent.com/43217/101205482-88fcf800-3622-11eb-911c-985f6ced4ff4.png)

Also, on Strategies, the pairs were set to `Token B` - `Token A`. I inverted it to be inline with deploy form.

# To Test
1. On deploy form
1. Pick two tokens
1. Fill in prices

- [x] Check prices are label in the selected `Token B`
- [x] Check the values at the bottom at the brackets visualization is labeled in `Token B`

1. On Strategies > Active tab
1. Expand one strategy

- [x] Check the values at the bottom at the brackets visualization is labeled in `Token B`

1. On every strategy tab (active, pending, closed)

- [x] Check the token pair is set to `Token A` - `Token B`

# Background

:crossed_fingers: 

