### PR TITLE
One more price to invert: active strategies table

### DIFF
--- a/src/components/basic/display/BracketsTable/Table.tsx
+++ b/src/components/basic/display/BracketsTable/Table.tsx
@@ -96,7 +96,7 @@ export const Table = memo(function Table(props: Props): JSX.Element {
 
   // Token components are repeated often, reusing same instance
   const priceTokenDisplay = (
-    <TokenDisplay token={baseTokenAddress} size="md" color="textGrey" />
+    <TokenDisplay token={quoteTokenAddress} size="md" color="textGrey" />
   );
   const baseTokenDisplay = (
     <TokenDisplay token={baseTokenAddress} size="md" color="text" />


### PR DESCRIPTION
# Description

One left over place to invert the prices.

Current:
![screenshot_2020-12-07_15-35-57](https://user-images.githubusercontent.com/43217/101418094-ed79ba80-38a1-11eb-9eee-c842d990113e.png)

After the fix:
![screenshot_2020-12-07_15-36-52](https://user-images.githubusercontent.com/43217/101418098-f1a5d800-38a1-11eb-9761-1400d1f7dd9e.png)


# To Test
1. On active strategies tab
1. Expand one strategy

- [x] Check prices labels on the table match the quote token label.

# Background

N/A

