### PR TITLE
Bug/#221/brackets view

### DIFF
--- a/src/components/pages/deploy/BracketsViewFragment.tsx
+++ b/src/components/pages/deploy/BracketsViewFragment.tsx
@@ -26,11 +26,19 @@ export const BracketsViewFragment = memo(
     const { values } = useFormState<DeployFormValues>();
 
     const totalBrackets = Number(values.totalBrackets);
-    const leftBrackets = useMemo(
+    // I know this is confusing, so let me explain:
+    // Base token brackets correspond to the amount of brackets that will be funded with
+    // base tokens, and the same goes for quote tokens.
+    // The lower end of the brackets will be first funded with quote tokens, then the remainder
+    // with base tokens.
+    // Since we display the price from left (lower) to right (higher):
+    // - quote will come on the left
+    // - base will come on the right
+    const rightBrackets = useMemo(
       () => getBracketValue(values.calculatedBrackets, "base"),
       [values.calculatedBrackets]
     );
-    const rightBrackets = useMemo(
+    const leftBrackets = useMemo(
       () => getBracketValue(values.calculatedBrackets, "quote"),
       [values.calculatedBrackets]
     );

--- a/src/utils/calculateBrackets.ts
+++ b/src/utils/calculateBrackets.ts
@@ -120,7 +120,7 @@ export function calculateBracketsFromMarketPrice(
     marketPrice.isNaN() ||
     lowestPrice.isNaN() ||
     highestPrice.isNaN() ||
-    lowestPrice >= highestPrice ||
+    lowestPrice.gte(highestPrice) ||
     !lowestPrice.gt(ZERO_DECIMAL) ||
     !marketPrice.gt(ZERO_DECIMAL) ||
     !totalBrackets.gt(ZERO_DECIMAL)

--- a/test/utils/calculateBracketsFromMarketPrice.test.ts
+++ b/test/utils/calculateBracketsFromMarketPrice.test.ts
@@ -132,6 +132,12 @@ describe("invalid params", () => {
     expect(calculateBracketsFromMarketPrice(params)).toEqual(invalidResponse);
   });
 
+  test("invalid lowestPrice", () => {
+    const params = clone(baseParams);
+    params.lowestPrice = params.highestPrice;
+    expect(calculateBracketsFromMarketPrice(params)).toEqual(invalidResponse);
+  });
+
   test("invalid highestPrice", () => {
     const params = clone(baseParams);
     params.highestPrice = params.lowestPrice;


### PR DESCRIPTION
# Description

Part of #221

Fixing brackets view coloring

## Before:
![screenshot_2020-12-08_12-24-05](https://user-images.githubusercontent.com/43217/101537431-515abc80-3950-11eb-8c00-0582433f4170.png)
![screenshot_2020-12-08_12-24-19](https://user-images.githubusercontent.com/43217/101537434-53bd1680-3950-11eb-938f-a0cba508bb40.png)

## After:
![screenshot_2020-12-08_12-23-19](https://user-images.githubusercontent.com/43217/101537443-57509d80-3950-11eb-8a7e-15be7455cda0.png)
![screenshot_2020-12-08_12-22-48](https://user-images.githubusercontent.com/43217/101537450-591a6100-3950-11eb-97c1-880e267fa6b5.png)


# To Test
- [ ] Check deploy form brackets
- [ ] Check active strategy brackets

# Background

This is a fix for correctly ordering the amount of brackets.

It still requires a fix on the bracket splitting to have an accurate representation of the brackets.
More details in this thread: https://gnosisinc.slack.com/archives/CC3C5SMB5/p1607449595149300

