### PR TITLE
Avoid app crashing when amounts are invalid

### DIFF
--- a/src/components/basic/inputs/TotalBrackets/index.tsx
+++ b/src/components/basic/inputs/TotalBrackets/index.tsx
@@ -62,7 +62,9 @@ export const TotalBrackets = (props: Props): JSX.Element => {
     const totalAmount = safeAddDecimals(baseAmountInUsd, quoteAmountInUsd);
 
     if (baseAmountInUsd || quoteAmountInUsd) {
-      return `~ $${formatSmart(totalAmount || "", 0)}`;
+      return `~ $${
+        totalAmount && !totalAmount.isNaN() ? formatSmart(totalAmount) : ""
+      }`;
     } else {
       return "-";
     }


### PR DESCRIPTION
# Description

Sometimes `totalValue` is NaN.

![screenshot_2020-12-15_13-28-00](https://user-images.githubusercontent.com/43217/102280175-7ff10e00-3ee1-11eb-8094-7e575f05d3eb.png)

Hard to reproduce bug. Saw this sporadically, not sure what's causing it.

In any way, this change prevents app crashing when `totalValue` is falsy or NaN.

# To Test
Fill in all fields in the deploy form.
Sometimes the total value calculation fails. 

- [ ] When that happens, the app shouldn't crash.

# Background

N/A

