### PR TITLE
Allowing USD amounts to be queried for USDC

### DIFF
--- a/src/api/prices.ts
+++ b/src/api/prices.ts
@@ -146,9 +146,9 @@ export async function getPrice(
   // base and quote being the same.
   // We don't want to query the price of a token against itself.
   if (baseToken.address === quoteToken.address) {
-    // Special case
+    // Unless... in this special case.
     // We use USDC to quote values as USD.
-    // If we want to use USDC on the strategy though, it'll be quoted against itself.
+    // If a user wants to use USDC on the strategy though, it'll be quoted against itself.
     // In that case, skip the check and return 1
     if (baseToken.symbol === "USDC") {
       return ONE_DECIMAL;

--- a/src/api/prices.ts
+++ b/src/api/prices.ts
@@ -146,6 +146,13 @@ export async function getPrice(
   // base and quote being the same.
   // We don't want to query the price of a token against itself.
   if (baseToken.address === quoteToken.address) {
+    // Special case
+    // We use USDC to quote values as USD.
+    // If we want to use USDC on the strategy though, it'll be quoted against itself.
+    // In that case, skip the check and return 1
+    if (baseToken.symbol === "USDC") {
+      return ONE_DECIMAL;
+    }
     return null;
   }
 


### PR DESCRIPTION
# Description

Fixed USDC having no USD estimation.

## Before:
![screenshot_2020-12-16_13-17-55](https://user-images.githubusercontent.com/43217/102407981-ce65e180-3fa1-11eb-8031-b9624720f63a.png)

## After:
![screenshot_2020-12-16_13-21-51](https://user-images.githubusercontent.com/43217/102407971-cb6af100-3fa1-11eb-9a96-2054db3a07d8.png)

# To Test
1. On deploy form, select USDC
2. Fill in the fields

- [ ] USDC should be accounted for in the total value estimation

# Background

We don't need to query any price source to know 1 USDC === 1 USDC :D

