### PR TITLE
Bug/funding validation failure

### DIFF
--- a/src/components/basic/inputs/TotalBrackets/index.tsx
+++ b/src/components/basic/inputs/TotalBrackets/index.tsx
@@ -62,9 +62,8 @@ export const TotalBrackets = (props: Props): JSX.Element => {
     const totalAmount = safeAddDecimals(baseAmountInUsd, quoteAmountInUsd);
 
     if (baseAmountInUsd || quoteAmountInUsd) {
-      return `~ $${
-        totalAmount && !totalAmount.isNaN() ? formatSmart(totalAmount) : ""
-      }`;
+      const formattedAmount = formatSmart(totalAmount);
+      return `~ $${formattedAmount ? formattedAmount : ""}`;
     } else {
       return "-";
     }

--- a/src/hooks/useAmountInUsd.ts
+++ b/src/hooks/useAmountInUsd.ts
@@ -29,7 +29,8 @@ export function useAmountInUsd(params: Params): Result {
 
   // Setting address to be queried `undefined` when no amount is provided
   // to avoid fetching price when there's no amount
-  const address = Number(amount) > 0 ? tokenAddress : undefined;
+  const address =
+    Number(amount) > 0 && !isNaN(+amount) ? tokenAddress : undefined;
 
   const baseToken = useTokenDetails(address);
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -21,7 +21,7 @@ export function formatSmart(
 ): string | null {
   let amountDecimal: Decimal;
 
-  if (amount === undefined) {
+  if (!amount) {
     return null;
   } else if (typeof amount === "string") {
     if (isNaN(+amount)) {
@@ -30,7 +30,7 @@ export function formatSmart(
 
     amountDecimal = new Decimal(amount);
   } else {
-    if (amount.isNaN()) {
+    if (amount.isNaN() || !amount.isFinite()) {
       return null;
     }
 

--- a/src/validators/hasBalance.ts
+++ b/src/validators/hasBalance.ts
@@ -20,8 +20,46 @@ export const hasBalanceFactory = (
   if (!tokenAddress || !value || !tokenBalance) {
     return undefined;
   }
+
   const details = await getErc20Details(tokenAddress);
+
+  // Maybe token details was not properly fetched?
+  if (!details.symbol || !details.decimals) {
+    console.error(
+      `Not able to load token details for address ${tokenAddress}. Got this:`,
+      details
+    );
+    return {
+      label: `Critical data missing`,
+      children: `Please reload the app. If the issue persists, reach out for support.`,
+    };
+  }
+
+  // Maybe the value provided is not a number?
+  if (isNaN(+value)) {
+    return {
+      label: `Invalid funding for ${details.symbol}`,
+      children: `"${value}" is not a valid number`,
+    };
+  }
+
   const bnAmount = parseAmount(value, details.decimals);
+
+  // Edge case, `parseAmount` does not return a valid BN
+  // This could happen when an invalid value is provided,
+  // or when decimals is undefined.
+  // Both should be treated above, but in any case, let's
+  // check it here as well to be safe
+  if (!bnAmount) {
+    console.error(
+      `Got a falsy "bnAmount" for value "${value}" and decimals "${details.decimals}":`,
+      bnAmount
+    );
+    return {
+      label: `Invalid funding for ${details.symbol}`,
+      children: `"${value}" is not a valid number`,
+    };
+  }
 
   if (bnAmount.gt(tokenBalance)) {
     return { label: `Insufficient balance for ${details.symbol} token` };


### PR DESCRIPTION
# Description

3 bug fixes

## 1 Attempt to fix reported user error

Was not able to reproduce issue.
Still, made the validation more resilient against null values.
Worst case it'll show an error message instead, giving at least some feedback.

## 2 Issue with price estimation breaking the app

The one I thought I fixed on https://github.com/gnosis/safe-cmm-app-react/pull/234
Hard to reproduce, got it again, and I think the reason was because the decimal value ends up being `Infinity`.
That case is now covered.

## 3 Trying to fetch prices for invalid amounts

Another one that in some circumstances causes the app to crash. The copy/paste issue Graeme discovered.
To reproduce, copy the estimated price amount and paste into any input field.
It should not crash anymore!

# Background

N/A

