### PR TITLE
Bug/empty string on inputs

### DIFF
--- a/src/components/pages/deploy/useStartPriceOutOfThreshold.ts
+++ b/src/components/pages/deploy/useStartPriceOutOfThreshold.ts
@@ -3,6 +3,7 @@ import Decimal from "decimal.js";
 import { useGetPrice } from "hooks/useGetPrice";
 import { useTokenDetails } from "hooks/useTokenDetails";
 
+import { safeStringToDecimal } from "utils/calculations";
 import { ONE_HUNDRED_DECIMAL } from "utils/constants";
 
 type UseIsStartPriceOutOfThresholdParams = {
@@ -24,19 +25,17 @@ export function useIsStartPriceOutOfThreshold(
 ): number | undefined {
   const { baseTokenAddress, quoteTokenAddress, startPrice, threshold } = params;
 
+  const startPriceDecimal = safeStringToDecimal(startPrice);
+
   // Avoid additional queries if `startPrice` is not set
-  const baseToken = useTokenDetails(startPrice ? baseTokenAddress : undefined);
-  const quoteToken = useTokenDetails(
-    startPrice ? quoteTokenAddress : undefined
-  );
+  const baseToken = useTokenDetails(startPriceDecimal && baseTokenAddress);
+  const quoteToken = useTokenDetails(startPriceDecimal && quoteTokenAddress);
 
   const { price } = useGetPrice({ baseToken, quoteToken });
 
-  if (!startPrice || isNaN(+startPrice) || !price) {
+  if (!startPriceDecimal || !price) {
     return undefined;
   }
-
-  const startPriceDecimal = new Decimal(startPrice);
 
   const priceDifferencePercentage = startPriceDecimal
     .minus(price)

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -24,6 +24,20 @@ export function safeAddDecimals(
   }
 }
 
+export function safeStringToDecimal(value?: string): Decimal | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue || isNaN(+trimmedValue) || !isFinite(+trimmedValue)) {
+    return undefined;
+  }
+
+  return new Decimal(trimmedValue);
+}
+
 /**
  * Calculates ROI based on difference between current|initial values.
  * Returns undefined when any input is invalid.

--- a/src/validators/hasBalance.ts
+++ b/src/validators/hasBalance.ts
@@ -43,7 +43,7 @@ export const hasBalanceFactory = (
     };
   }
 
-  const bnAmount = parseAmount(value, details.decimals);
+  const bnAmount = parseAmount(value.trim(), details.decimals);
 
   // Edge case, `parseAmount` does not return a valid BN
   // This could happen when an invalid value is provided,


### PR DESCRIPTION
# Description

Fixing - once and for all - issues with bad input breaking the app

Related to #238 

Found out what was causing:
1. App to break when copy/pasting values into the input (#238 issue 2)
2. Issue that prevented user from submitting the form, which I attempted to fix on #238 issue 1

# To Test
1. On deploy form, pick any 2 tokens
2. Copy paste the full price estimation value into ALL inputs

- [ ] Notice that the copied value start with an empty string
- [ ] It should not cause the app to break
- [ ] You should be able to submit the form

# Background

Managed to reproduce user error. This should fix it :crossed_fingers: 

