### PR TITLE
Label shouldn't be displayed when equal to upper boundary

### DIFF
--- a/src/components/basic/display/BracketsView/Needle.tsx
+++ b/src/components/basic/display/BracketsView/Needle.tsx
@@ -45,7 +45,7 @@ export const Needle = memo(function Needle(): JSX.Element {
 
   return (
     <Wrapper needlePosition={needlePosition}>
-      {needlePosition >= lowerThreshold && needlePosition <= upperThreshold && (
+      {needlePosition >= lowerThreshold && needlePosition < upperThreshold && (
         <>
           <NeedleLabel onNeedle />
           {startPrice && (


### PR DESCRIPTION
# Description

Fixes #224 

Before:
![screenshot_2020-12-31_14-04-24](https://user-images.githubusercontent.com/43217/103426832-1a538180-4b71-11eb-88e1-3e95d0d295d3.png)

After:
![screenshot_2020-12-31_14-05-29](https://user-images.githubusercontent.com/43217/103426842-3bb46d80-4b71-11eb-91fe-7b1ac50c5898.png)


# To Test
1. On deploy page, insert the following values:
2. lowest price: 0.95
3. start price: 0.99
4. highest price: 1

- [ ] Check the brackets view does not overlap

# Background

N/A
