### PR TITLE
Bug/#124/clear out funding when disabled

### DIFF
--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -159,26 +159,20 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
             />
           )}
         />
-        <Field<string> name="baseTokenBrackets" subscription={{ value: true }}>
-          {({ input: { value } }) => (
-            // Field `baseTokenAmount` is "subscribed" to field `baseTokenBrackets`
-            // `baseTokenBrackets` value is a string storing base brackets value
-            <Field<string>
-              name="baseTokenAmount"
-              // validation done at form level since this field might not be used
-              render={({ input, meta }) => (
-                <FundingInput
-                  {...input}
-                  warn={meta.touched && meta.data?.warn}
-                  error={meta.touched && meta.error}
-                  brackets={+value}
-                  tokenAddress={baseTokenAddress}
-                  onMaxClick={onBaseTokenMaxClick}
-                />
-              )}
+        <Field<string>
+          name="baseTokenAmount"
+          // validation done at form level since this field might not be used
+          render={({ input, meta }) => (
+            <FundingInput
+              {...input}
+              warn={meta.touched && meta.data?.warn}
+              error={meta.touched && meta.error}
+              brackets={+baseTokenBrackets}
+              tokenAddress={baseTokenAddress}
+              onMaxClick={onBaseTokenMaxClick}
             />
           )}
-        </Field>
+        />
       </div>
       <div className="middle">
         <Field<string>
@@ -240,26 +234,20 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
             />
           )}
         />
-        <Field<string> name="quoteTokenBrackets" subscription={{ value: true }}>
-          {({ input: { value } }) => (
-            // Field `quoteTokenAmount` is "subscribed" to field `quoteTokenBrackets`
-            // `quoteTokenBrackets` value is a string storing quote brackets value
-            <Field<string>
-              name="quoteTokenAmount"
-              // validation done at form level since this field might not be used
-              render={({ input, meta }) => (
-                <FundingInput
-                  {...input}
-                  warn={meta.touched && meta.data?.warn}
-                  error={meta.touched && meta.error}
-                  brackets={+value}
-                  tokenAddress={quoteTokenAddress}
-                  onMaxClick={onQuoteTokenMaxClick}
-                />
-              )}
+        <Field<string>
+          name="quoteTokenAmount"
+          // validation done at form level since this field might not be used
+          render={({ input, meta }) => (
+            <FundingInput
+              {...input}
+              warn={meta.touched && meta.data?.warn}
+              error={meta.touched && meta.error}
+              brackets={+quoteTokenBrackets}
+              tokenAddress={quoteTokenAddress}
+              onMaxClick={onQuoteTokenMaxClick}
             />
           )}
-        </Field>
+        />
       </div>
     </Wrapper>
   );

--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from "react";
+import React, { memo, useCallback, useEffect } from "react";
 import { Field, useField, useForm } from "react-final-form";
 import styled from "styled-components";
 import BN from "bn.js";
@@ -63,12 +63,40 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
     input: { value: baseTokenAmount },
   } = useField<string>("baseTokenAmount");
   const {
+    input: { value: baseTokenBrackets },
+  } = useField<string>("baseTokenBrackets");
+  const {
     input: { value: quoteTokenAmount },
   } = useField<string>("quoteTokenAmount");
+  const {
+    input: { value: quoteTokenBrackets },
+  } = useField<string>("quoteTokenBrackets");
 
   const {
     mutators: { setFieldValue },
+    change,
+    resetFieldState,
   } = useForm();
+
+  // Resetting amount fields when they are disabled
+  const resetAmountField = useCallback(
+    (bracketsInput: string, amountFieldName: string): void => {
+      if (!+bracketsInput) {
+        change(amountFieldName, undefined);
+        resetFieldState(amountFieldName);
+      }
+    },
+    [change, resetFieldState]
+  );
+
+  useEffect(() => resetAmountField(baseTokenBrackets, "baseTokenAmount"), [
+    baseTokenBrackets,
+    resetAmountField,
+  ]);
+  useEffect(() => resetAmountField(quoteTokenBrackets, "quoteTokenAmount"), [
+    quoteTokenBrackets,
+    resetAmountField,
+  ]);
 
   const baseTokenDetails = useTokenDetails(baseTokenAddress);
   const quoteTokenDetails = useTokenDetails(quoteTokenAddress);


### PR DESCRIPTION
# Description

Fixes #124

# To Test
1. On deploy form, fill in the prices like so: `1`, `2`, `3` respectively (or any sequence)
2. Fill in any number from 2 to 10 in the brackets input
3. Once amount inputs are enabled, fill in both with any positive value
4. Change the start price to `1`

- [ ] Funding input on the right should be disabled and cleared out

5. Change the start price to `3`

- [ ] Funding input on the left should be disabled and cleared out

# Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

