### PR TITLE
Bug/#88/max button work when input disabled

### DIFF
--- a/src/components/pages/deploy/PricesFragment.tsx
+++ b/src/components/pages/deploy/PricesFragment.tsx
@@ -125,17 +125,24 @@ export const PricesFragment = memo(function PricesFragment(): JSX.Element {
 
   const onBaseTokenMaxClick = useCallback(
     () =>
+      +baseTokenBrackets &&
       onMaxClickFactory("baseTokenAmount", baseTokenDetails, baseTokenBalance),
-    [baseTokenDetails, onMaxClickFactory, baseTokenBalance]
+    [baseTokenBrackets, onMaxClickFactory, baseTokenDetails, baseTokenBalance]
   );
   const onQuoteTokenMaxClick = useCallback(
     () =>
+      +quoteTokenBrackets &&
       onMaxClickFactory(
         "quoteTokenAmount",
         quoteTokenDetails,
         quoteTokenBalance
       ),
-    [onMaxClickFactory, quoteTokenDetails, quoteTokenBalance]
+    [
+      quoteTokenBrackets,
+      onMaxClickFactory,
+      quoteTokenDetails,
+      quoteTokenBalance,
+    ]
   );
 
   return (


### PR DESCRIPTION
# :warning: Depends on https://github.com/gnosis/safe-cmm-app-react/pull/250 :warning: 

Merge only after #250 is merged

# Description

Fixes #88

# To Test
1. On deploy page, pick two tokens where you have balance for at least 1 of them
2. Fill in all prices in a sequence, such as `1`, `2`, `3`
3. Click on max button for the tokens you have a balance

- [ ] Respective disabled input field should remain empty

4. Fill in total brackets
5. Amount inputs should be enabled now. Click on max buttons for tokens where you have a balance

- [ ] Respective enabled input field should be filled with your balance

# Background

N/A

